### PR TITLE
Update BoletoNetCore.Tests netcoreapp3.0

### DIFF
--- a/BoletoNetCore.Testes/BoletoNetCore.Testes.csproj
+++ b/BoletoNetCore.Testes/BoletoNetCore.Testes.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adicionado netcoreapp3.0 como target framework do projeto BoletoNetCore.Tests.

Por que?
Para que projetos desenvolvidos em netcoreapp3.0, juntamente com
netcoreapp2.0, possuam cobertura de testes.