### PR TITLE
[Sugestão] - Imprimir sempre as mensagens de instrução

### DIFF
--- a/BoletoNetCore/Banco/Banco.cs
+++ b/BoletoNetCore/Banco/Banco.cs
@@ -88,10 +88,12 @@ namespace BoletoNetCore
                 boleto.MensagemInstrucoesCaixaFormatado += $"DESCONTO DE R$ {boleto.ValorDesconto.ToString("N2")} ATÉ {boleto.DataDesconto.ToString("dd/MM/yyyy")}{Environment.NewLine}";
             }
 
-            if (boleto.ImprimirValoresAuxiliares == true && boleto.MensagemInstrucoesCaixa?.Length > 0)
+            if (/*boleto.ImprimirValoresAuxiliares == true && */ boleto.MensagemInstrucoesCaixa?.Length > 0)
             {
                 boleto.MensagemInstrucoesCaixaFormatado += Environment.NewLine;
                 boleto.MensagemInstrucoesCaixaFormatado += boleto.MensagemInstrucoesCaixa;
+
+                boleto.MensagemInstrucoesCaixaFormatado = boleto.MensagemInstrucoesCaixaFormatado.Trim();
             }
 
         }


### PR DESCRIPTION
Nos meus boletos, adiciono as mensagens de instrução de forma manual, assim:

```
if (ContaBancaria.Multa > 0)
{
    boleto.DataMulta = fatura.Vencimento.AddDays(1);
    boleto.PercentualMulta = ContaBancaria.Multa;
    boleto.ValorMulta = Funcoes.Arredondar(boleto.ValorTitulo * boleto.PercentualMulta / 100, 2);

    boleto.MensagemInstrucoesCaixa = $"Cobrar Multa de {boleto.ValorMulta:C2} após o vencimento.";
}

if (ContaBancaria.Mora > 0)
{
    boleto.DataJuros = fatura.Vencimento.AddDays(1);
    boleto.PercentualJurosDia = (ContaBancaria.Mora / 30);
    boleto.ValorJurosDia = Funcoes.Arredondar(boleto.ValorTitulo * boleto.PercentualJurosDia / 100, 2);

    string instrucao = $"Cobrar juros de {boleto.PercentualJurosDia:N2} % por dia de atraso";
    if (string.IsNullOrEmpty(boleto.MensagemInstrucoesCaixa))
        boleto.MensagemInstrucoesCaixa = instrucao;
    else
        boleto.MensagemInstrucoesCaixa += Environment.NewLine + instrucao;
}

```

Faço isso no boleto2Net e funciona perfeitamente. Porém, no BoletoNetCore, tive que fazer uma alteração "forçada" para imprimir as instruções, assim:

```
boleto.ValidarDados();

if (!boleto.ImprimirValoresAuxiliares)
    boleto.MensagemInstrucoesCaixaFormatado = boleto.MensagemInstrucoesCaixa.Replace(Environment.NewLine, "</br>");
```

Por que isso? A variável "ImprimirValoresAuxiliares" tem que estar falsa para mim, pois ela adiciona, inclusive os valores de juros e desconto à esquerda.

Mandei uma sugestão de mudança, a ideia não é que o PR seja aceito, mas que discutamos a possibilidade de ou sempre imprimir o atributo "MensagemInstrucoesCaixa" ou criar um novo atributo que controle essa opção de forma isolada.