### PR TITLE
A propriedade NomeArquivo não estava considerando para gerar o arquiv…

### DIFF
--- a/BoletoNetCore/Banco/Sicredi/BancoSicredi.cs
+++ b/BoletoNetCore/Banco/Sicredi/BancoSicredi.cs
@@ -37,10 +37,15 @@ namespace BoletoNetCore
             if (mes == "12") mes = "D";
             var dia = agora.Day.ToString().PadLeft(2, '0');
 
-            //Caso for gerado mais de um arquivo de remessa alterar a extensão do aquivo para "RM" + o contador do numero do arquivo de remessa gerado no dia
-            var nomeArquivoRemessa = string.Format("{0}{1}{2}.{3}", Beneficiario.Codigo, mes, dia, "CRM");
+            if (sequencial < 0 || sequencial > 10)
+                throw BoletoNetCoreException.NumeroSequencialInvalido(sequencial);
 
-            return nomeArquivoRemessa;
+            if (sequencial < 1) // se 0 ou 1 é o primeiro arquivo do dia
+                return string.Format("{0}{1}{2}.{3}", Beneficiario.Codigo, mes, dia, "CRM");
+
+            //número máximos de arquivos enviados no dia são 10 
+            return string.Format("{0}{1}{2}.{3}", Beneficiario.Codigo, mes, dia, $"RM{(sequencial == 10 ? 0 : sequencial)}");
+
         }
        
     }

--- a/BoletoNetCore/Exceptions/BoletoNetCoreException.cs
+++ b/BoletoNetCore/Exceptions/BoletoNetCoreException.cs
@@ -52,5 +52,7 @@ namespace BoletoNetCore.Exceptions
         public static Exception CarteiraNaoImplementada(string carteiraComVariacao)
             => new BoletoNetCoreException($"Carteira não implementada: {carteiraComVariacao}");
 
+        public static Exception NumeroSequencialInvalido(int numeroSequencial)
+            => new BoletoNetCoreException($"Número sequencial é inválido: {numeroSequencial}");
     }
 }


### PR DESCRIPTION
Quando o arquivo de remessa não for o primeiro do dia a extensão deveria ser RMX, onde X seria o número sequencial do arquivo no dia, a sicredi somente aceita 10 arquivo por dia o décimo arquivo o valor de X deve ser 0(zero)
