### PR TITLE
Sicredi - Data de Crédito

### DIFF
--- a/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
@@ -262,7 +262,7 @@ namespace BoletoNetCore
                 boleto.ValorPago += boleto.ValorJurosDia;
 
                 // Data do Crédito
-                boleto.DataCredito = Utils.ToDateTime(Utils.ToInt32(registro.Substring(294, 6)).ToString("##-##-##"));
+                boleto.DataCredito = Utils.ToDateTime(Utils.ToInt32(registro.Substring(328, 8)).ToString("####-##-##"));
 
                 // Identificação de Ocorrência - Código Auxiliar
                 boleto.CodigoMotivoOcorrencia = registro.Substring(381, 10);


### PR DESCRIPTION
Ajustado para pegar a data de crédito na posição correta

Conforme o manual página 54 campo Data prevista para lançamento no conta corrente

Foram feitos vários testes e não vem data na posição que estava pegando antes.

É nessa posição 329 a 336 que vem a data.

Alteração já foi feita no boleto2net https://github.com/BoletoNet/boleto2net/pull/218