### PR TITLE
Ajuste no método FormataLogradouro

### DIFF
--- a/BoletoNetCore/Boleto/Endereco.cs
+++ b/BoletoNetCore/Boleto/Endereco.cs
@@ -19,7 +19,7 @@ namespace BoletoNetCore
             if (!string.IsNullOrEmpty(LogradouroNumero))
                 logradouroCompleto += " " + LogradouroNumero;
             if (!string.IsNullOrEmpty(LogradouroComplemento))
-                logradouroCompleto += " " + LogradouroComplemento;
+                logradouroCompleto += " " + (LogradouroComplemento.Length > 20 ? LogradouroComplemento.Substring(0, 20) : LogradouroComplemento);
 
             if (tamanhoFinal == 0)
                 return LogradouroEndereco + logradouroCompleto;


### PR DESCRIPTION
Quando passava um complemento muito grande, a ultima linha desse método dava um erro,

Aqui
`return LogradouroEndereco.Substring(0, tamanhoFinal - logradouroCompleto.Length) + logradouroCompleto;`

Quando o complemento era muito grande, o tamanho de logradouroCompleto ficava maior que tamanhoFinal, e a subtração (tamanhoFinal - logradouroCompleto.Length) dava um número negativo causando o erro.

Ajustei para cortar em no máximo 20 o complemento, com isso o logradouroCompleto não terá mais de 40 caracteres como estava passível de ter antes.

O campo número fiquei na dúvida se faria esse tratamento, pra o meu caso não precisa porque é inteiro e apenas converto pra string.

Alteração já foi feita no boleto2net https://github.com/BoletoNet/boleto2net/pull/217