### PR TITLE
Preencher campo Numero de Controle do Participante ao ler o retorno (Sicredi)

### DIFF
--- a/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
@@ -248,6 +248,9 @@ namespace BoletoNetCore
                 // Número do Documento
                 boleto.NumeroDocumento = registro.Substring(116, 10).Trim();
 
+                // Seu número - Seu número enviado na Remessa
+                boleto.NumeroControleParticipante = registro.Substring(116, 10).Trim();
+
                 //Data Vencimento do Título
                 boleto.DataVencimento = Utils.ToDateTime(Utils.ToInt32(registro.Substring(146, 6)).ToString("##-##-##"));
 


### PR DESCRIPTION
Alteração referente a essa discussão https://github.com/BoletoNet/boleto2net/issues/214

Já foi implementada no boleto2net