### PR TITLE
Incrementar numero registro Sicredi CNAB400

### DIFF
--- a/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
@@ -10,6 +10,8 @@ namespace BoletoNetCore
         {
             string detalhe = string.Empty;
 
+            registro++;
+
             //Redireciona para o Detalhe da remessa Conforme o "Tipo de Documento" = "Tipo de Cobrança do CNAB400":
             //  A = 'A' - SICREDI com Registro
             // C1 = 'C' - SICREDI sem Registro Impressão Completa pelo Sicredi


### PR DESCRIPTION
Ver #99 

Ao gerar remessa Sicredi CNAB 400 estava passando sempre 0 na posição  395 à 400

![image](https://user-images.githubusercontent.com/46816210/110468461-14b97100-80b7-11eb-9504-a44d3190bb6f.png)
