### PR TITLE
erro ao ler remessa quando o beneficiário é null

### DIFF
--- a/BoletoNetCore/Boleto/Boleto.cs
+++ b/BoletoNetCore/Boleto/Boleto.cs
@@ -32,7 +32,7 @@ namespace BoletoNetCore
         {
             Banco = banco;
             //se o arquivo de retorno for criado par multiplas carteiras, ignora a carteira (para compatibilidade)
-            if (!ignorarCarteira)
+            if (!ignorarCarteira && banco.Beneficiario != null)
             {
                 Carteira = banco.Beneficiario.ContaBancaria.CarteiraPadrao;
                 VariacaoCarteira = banco.Beneficiario.ContaBancaria.VariacaoCarteiraPadrao;


### PR DESCRIPTION
quando cria a instancia de um boleto e o beneficiário é null, acontece na caixa