### PR TITLE
Dígitos de Beneficiario.CodigoFormatado

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.cs
@@ -28,7 +28,7 @@ namespace BoletoNetCore
             if (Beneficiario.Codigo.Length != 7)
                 throw BoletoNetCoreException.CodigoBeneficiarioInvalido(Beneficiario.Codigo, 7);
 
-            Beneficiario.CodigoFormatado = $"{contaBancaria.Agencia}-{contaBancaria.DigitoAgencia} / {contaBancaria.Conta}-{contaBancaria.DigitoConta}";
+            Beneficiario.CodigoFormatado = $"{contaBancaria.Agencia}{(string.IsNullOrEmpty(contaBancaria.DigitoAgencia) ? "" : "-" + contaBancaria.DigitoAgencia)} / {contaBancaria.Conta}{(string.IsNullOrEmpty(contaBancaria.DigitoConta) ? "" : "-" + contaBancaria.DigitoConta)}";
         }
 
     }


### PR DESCRIPTION
Não coloca os dígitos de agência e conta corrente no campo CodigoFormatado do Banco do Brasil quando não houver essa informação.
Ex.: Foi utilizado os dados de teste da API de cobrança do Banco do Brasil que não contém dígitos em agência e conta (https://apoio.developers.bb.com.br/referency/post/5ffc477c3b02bd0012ecaa1a)