### PR TITLE
Acrescentado o código de carteira 17/035

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/Carteiras/BancoBrasilCarteira17.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/Carteiras/BancoBrasilCarteira17.cs
@@ -3,7 +3,7 @@ using static System.String;
 
 namespace BoletoNetCore
 {
-    [CarteiraCodigo("17/019", "17/027")]
+    [CarteiraCodigo("17/019", "17/027", "17/035")]
     internal class BancoBrasilCarteira17 : ICarteira<BancoBrasil>
     {
         internal static Lazy<ICarteira<BancoBrasil>> Instance { get; } = new Lazy<ICarteira<BancoBrasil>>(() => new BancoBrasilCarteira17());


### PR DESCRIPTION
Alteração pra permitir a utilização da carteira 17 com variação 035 no Banco do Brasil