### PR TITLE
posicao 210 a 212 do segmento Q deve ser preenchido com zeros

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
@@ -384,7 +384,11 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0154, 001, 0, boleto.Avalista.TipoCPFCNPJ("0"), '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0155, 015, 0, boleto.Avalista.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0170, 040, 0, boleto.Avalista.Nome, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0210, 003, 0, string.Empty, ' ');
+
+                // conforme manual disponivel em https://www.bb.com.br/docs/pub/emp/empl/dwn/CbrVer04BB.pdf
+                // "Campo não tratado. Preencher com 'zeros'."
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0210, 003, 0, 0, '0');
+
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0213, 020, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0233, 008, 0, string.Empty, ' ');
                 reg.CodificarLinha();


### PR DESCRIPTION
conforme manual disponivel em https://www.bb.com.br/docs/pub/emp/empl/dwn/CbrVer04BB.pdf
 "Campo não tratado. Preencher com 'zeros'."
a posição 210 a 212 do segmento P deve ser preenchido com zeros, atualmente estava sendo preenchido com espacos.