### PR TITLE
formatar nome do arquivo de remessa para banco do brasil

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.cs
@@ -5,7 +5,7 @@ using BoletoNetCore.Extensions;
 
 namespace BoletoNetCore
 {
-    internal sealed partial class BancoBrasil : BancoFebraban<BancoBrasil> , IBanco
+    internal sealed partial class BancoBrasil : BancoFebraban<BancoBrasil>, IBanco
     {
         public BancoBrasil()
         {
@@ -14,6 +14,11 @@ namespace BoletoNetCore
             Digito = "9";
             IdsRetornoCnab400RegistroDetalhe = new List<string> { "7" };
             RemoveAcentosArquivoRemessa = true;
+        }
+
+        public override string FormatarNomeArquivoRemessa(int numeroSequencial)
+        {
+            return $"CB{DateTime.Now.Date.Day:00}{DateTime.Now.Date.Month:00}{numeroSequencial.ToString().PadLeft(9, '0').Right(2)}.rem";
         }
 
         public void FormataBeneficiario()


### PR DESCRIPTION
O projeto ACBr usa o padrão geral como CBddMMXX.rem
dd = dia com dois digitos
MM = mes com dois dígitos
XX = sequencia

Fiz o ajuste diretamente na classe do banco do brasil, mas deixo como sugestão, posso ate implementar aqui se quiser, colocar isso na classe BancoFebraban<>, assim, a implementação precisaria ser feita apenas para os bancos que tem particularidades no nome do arquivo, como sicredi por exemplo.