### PR TITLE
Negativação sem Protesto p/ Banco do Brasil Remessa CNAB240

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
@@ -322,6 +322,9 @@ namespace BoletoNetCore
                     case TipoCodigoProtesto.ProtestarDiasUteis:
                         reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 2, '0');
                         break;
+                    case TipoCodigoProtesto.NegativacaoSemProtesto:
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 8, '0');
+                        break;
                     default:
                         reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 0, '0');
                         break;

--- a/BoletoNetCore/Enums/TipoCodigoProtesto.cs
+++ b/BoletoNetCore/Enums/TipoCodigoProtesto.cs
@@ -6,6 +6,7 @@
         ProtestarDiasCorridos = 1,
         ProtestarDiasUteis = 2,
         UtilizarPerfilBeneficiario = 3,
-        CancelamentoProtestoAutomatico = 4
+        CancelamentoProtestoAutomatico = 4,
+        NegativacaoSemProtesto = 8
     }
 }


### PR DESCRIPTION
Adicionado NegativacaoSemProtesto no enum TipoCodigoProtesto; Realizado tratamento na remessa CNAB240 do Banco do Brasil para considerar o novo tipo NegativacaoSemProtesto; Manual BB disponível em https://www.bb.com.br/docs/pub/emp/empl/dwn/CNAB240SegPQRSTY.pdf pagina 14 campo 36.3P posicao 221 do segmento P