### PR TITLE
Boleto CAIXA com 7 dígitos no beneficiário.

### DIFF
--- a/BoletoNetCore/Banco/Caixa/BancoCaixa.cs
+++ b/BoletoNetCore/Banco/Caixa/BancoCaixa.cs
@@ -26,12 +26,28 @@ namespace BoletoNetCore
             contaBancaria.FormatarDados("PREFERENCIALMENTE NAS CASAS LOTERICAS ATE O VALOR LIMITE", "", "SAC CAIXA: 0800 726 0101 (informações, reclamações, sugestões e elogios)<br>Para pessoas com deficiência auditiva ou de fala: 0800 726 2492<br>Ouvidoria: 0800 725 7474<br>caixa.gov.br<br>", 6);
 
             var codigoBeneficiario = Beneficiario.Codigo;
-            Beneficiario.Codigo = codigoBeneficiario.Length <= 6 ? codigoBeneficiario.PadLeft(6, '0') : throw BoletoNetCoreException.CodigoBeneficiarioInvalido(codigoBeneficiario, 6);
+            if (codigoBeneficiario.Length <= 6)
+            {
+                Beneficiario.Codigo = codigoBeneficiario.PadLeft(6, '0');
 
-            if (Beneficiario.CodigoDV == Empty)
-                throw new Exception($"Dígito do código do beneficiário ({codigoBeneficiario}) não foi informado.");
+                if (Beneficiario.CodigoDV == Empty)
+                    throw new Exception($"Dígito do código do beneficiário ({codigoBeneficiario}) não foi informado.");
 
-            Beneficiario.CodigoFormatado = $"{contaBancaria.Agencia} / {codigoBeneficiario}-{Beneficiario.CodigoDV}";
+                Beneficiario.CodigoFormatado = $"{contaBancaria.Agencia} / {codigoBeneficiario}-{Beneficiario.CodigoDV}";
+            }
+            else if (codigoBeneficiario.Length == 7)
+            {
+                Beneficiario.Codigo = codigoBeneficiario;
+
+                if (Beneficiario.CodigoDV != Empty)
+                    throw new Exception($"Dígito do código do beneficiário ({codigoBeneficiario}) não deve ser informado quando codigo beneficiario tiver 7 dígitos.");
+
+                Beneficiario.CodigoFormatado = $"{contaBancaria.Agencia} / {codigoBeneficiario}";
+            }
+            else
+            {
+                throw BoletoNetCoreException.CodigoBeneficiarioInvalido(codigoBeneficiario, "6 ou 7");
+            }
         }
 
         public override string FormatarNomeArquivoRemessa(int numeroSequencial)

--- a/BoletoNetCore/Exceptions/BoletoNetCoreException.cs
+++ b/BoletoNetCore/Exceptions/BoletoNetCoreException.cs
@@ -49,6 +49,9 @@ namespace BoletoNetCore.Exceptions
         public static Exception CodigoBeneficiarioInvalido(string codigoBeneficiario, int digitos)
             => new BoletoNetCoreException($"O código do beneficiário ({codigoBeneficiario}) deve conter {digitos} dígitos.");
 
+        public static Exception CodigoBeneficiarioInvalido(string codigoBeneficiario, string digitos)
+            => new BoletoNetCoreException($"O código do beneficiário ({codigoBeneficiario}) deve conter {digitos} dígitos.");
+
         public static Exception CarteiraNaoImplementada(string carteiraComVariacao)
             => new BoletoNetCoreException($"Carteira não implementada: {carteiraComVariacao}");
 


### PR DESCRIPTION
CAIXA - adicionado suporte para 7 digitos de beneficiario para geração e impressão boleto sig14. 

**Não foi modificado remessa/retorno**
