### PR TITLE
Ajuste para impedir mensagem de multa e juros duplicada

### DIFF
--- a/BoletoNetCore/Banco/Banco.cs
+++ b/BoletoNetCore/Banco/Banco.cs
@@ -109,7 +109,7 @@ namespace BoletoNetCore
         ///     2° campo
         ///     composto pelas posições 6ª a 15ª do campo livre e o dígito verificador deste campo;
         ///     3º campo
-        ///     composto pelas posiçes 16ª a 25ª do campo livre e o dígito verificador deste campo;
+        ///     composto pelas posições 16ª a 25ª do campo livre e o dígito verificador deste campo;
         ///     4º campo
         ///     composto pelo dígito verificador do código de barras, ou seja, a 5ª posição do código de
         ///     barras;


### PR DESCRIPTION
Ajuste para impedir a mensagem de multa e juros duplicada, ao informar juros em percentual e em valor, estava aparecendo nas mensagens os dois formatos, realizei o ajuste para priorizar a instrução com valor da multa e dos juros, apenas se nao houver essa informação, será utilizado a mensagem com percentual