### PR TITLE
CNAB400 Itau - campo de prazo zerado

### DIFF
--- a/BoletoNetCore.QuestPdf/Carne/ReciboLateralCarne.cs
+++ b/BoletoNetCore.QuestPdf/Carne/ReciboLateralCarne.cs
@@ -33,7 +33,7 @@ namespace BoletoNetCore.QuestPdf
 
                     row.RelativeColumn().Stack(st =>
                     {
-                        st.Item().Text("Vncimento", BoletoPdfConstants.LabelStyle);
+                        st.Item().Text("Vencimento", BoletoPdfConstants.LabelStyle);
                         st.Item().Text(this.boleto.DataVencimento.ToDateStr(), BoletoPdfConstants.BoldFieldStyle);
                     });
                 });

--- a/BoletoNetCore/Banco/Itau/BancoItau.CNAB400.cs
+++ b/BoletoNetCore/Banco/Itau/BancoItau.CNAB400.cs
@@ -110,7 +110,7 @@ namespace BoletoNetCore
                     reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0382, 004, 0, Empty, ' ');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0386, 006, 0, "0", '0');
                 }
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0392, 002, 0, "0", '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0392, 002, 0, boleto.DiasProtesto, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0394, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
                 reg.CodificarLinha();

--- a/BoletoNetCore/Banco/Itau/Carteiras/BancoItauCarteira157.cs
+++ b/BoletoNetCore/Banco/Itau/Carteiras/BancoItauCarteira157.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using BoletoNetCore.Extensions;
+using static System.String;
+
+
+namespace BoletoNetCore
+{
+    [CarteiraCodigo("157")]
+    internal class BancoItauCarteira157 : ICarteira<BancoItau>
+    {
+        internal static Lazy<ICarteira<BancoItau>> Instance { get; } = new Lazy<ICarteira<BancoItau>>(() => new BancoItauCarteira157());
+
+        private BancoItauCarteira157()
+        {
+
+        }
+
+        public void FormataNossoNumero(Boleto boleto)
+        {
+            if (IsNullOrWhiteSpace(boleto.NossoNumero))
+                throw new Exception("Nosso Número não informado.");
+
+            // Nosso número não pode ter mais de 8 dígitos
+            if (boleto.NossoNumero.Length > 8)
+                throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve conter 8 dígitos.");
+
+            boleto.NossoNumero = boleto.NossoNumero.PadLeft(8, '0');
+            boleto.NossoNumeroDV = (boleto.Banco.Beneficiario.ContaBancaria.Agencia + boleto.Banco.Beneficiario.ContaBancaria.Conta + boleto.Carteira + boleto.NossoNumero).CalcularDVItau();
+            boleto.NossoNumeroFormatado = $"{boleto.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
+        }
+
+        public string FormataCodigoBarraCampoLivre(Boleto boleto)
+        {
+            return $"{boleto.Carteira}{boleto.NossoNumero}{boleto.NossoNumeroDV}{boleto.Banco.Beneficiario.ContaBancaria.Agencia}{boleto.Banco.Beneficiario.ContaBancaria.Conta}{boleto.Banco.Beneficiario.ContaBancaria.DigitoConta}000";
+        }
+    }
+}


### PR DESCRIPTION
Estou usando o BoletoNetCore para fazer o CNAB400 do Itau, e no meu caso, aplico um prazo de 10 dias de protesto, mas no arquivo [BancoItau.CNAB400.cs](https://github.com/BoletoNet/BoletoNetCore/blob/master/BoletoNetCore/Banco/Itau/BancoItau.CNAB400.cs), na linha 113, ele está passando 0 nesse registro, na hora de preencher a posição 392 e 393.

Neste caso a propriedade `boleto.DiasProtesto` poderia fazer este papel tal qual está fazendo em outros layouts. Como essa parte de protesto é bem incomum de ser usada, acho que quem usava contava com o padrão de sempre (causando se não me engano 2 dias úteis de prazo)

De acordo com o manual... 
![image](https://user-images.githubusercontent.com/4689962/139344010-1e91a382-a9a6-4ef9-a84c-dd91d13d4ebc.png)

**TL;DR**
Posição 392 e 393 do detalhe de remessa está sendo sempre preenchida com 0 no CNAB400 do Itau. Trocado para usar boleto.DiasProtesto.