### PR TITLE
Caixa (104) - Ajuste no arquivo de remessa para beneficiário de 7 digitos e no prazo de recebimento que esta zerado.

### DIFF
--- a/BoletoNetCore/Banco/Caixa/BancoCaixa.CNAB400.cs
+++ b/BoletoNetCore/Banco/Caixa/BancoCaixa.CNAB400.cs
@@ -26,7 +26,17 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0077, 003, 0, "104", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0080, 015, 0, "CEF", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAA___________, 0095, 006, 0, DateTime.Now, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0101, 289, 0, Empty, ' ');
+
+                if (Beneficiario.Codigo.Length == 7)
+                {
+                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0101, 003, 0, "007", ' ');
+                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0104, 286, 0, Empty, ' ');
+                }
+                else
+                {
+                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0101, 289, 0, Empty, ' ');
+                }
+
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0390, 005, 0, numeroArquivoRemessa, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
 
@@ -94,7 +104,8 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAA___________, 0352, 006, 0, boleto.DataMulta, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0358, 010, 2, boleto.ValorMulta, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0368, 022, 0, boleto.Avalista.Nome, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0390, 004, 0, "0", '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0390, 002, 0, "0", '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0392, 002, 0, boleto.DiasLimiteRecebimento.HasValue ? boleto.DiasLimiteRecebimento.Value.ToString("00") : "99", '0'); // Caso não for informado, irá definir o máximo de dias "99".
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0394, 001, 0, "1", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
 

--- a/BoletoNetCore/Banco/Caixa/BancoCaixa.cs
+++ b/BoletoNetCore/Banco/Caixa/BancoCaixa.cs
@@ -1,7 +1,7 @@
 using BoletoNetCore.Exceptions;
+using BoletoNetCore.Extensions;
 using System;
 using System.Collections.Generic;
-using static System.String;
 
 namespace BoletoNetCore
 {

--- a/BoletoNetCore/Boleto/Boleto.cs
+++ b/BoletoNetCore/Boleto/Boleto.cs
@@ -211,10 +211,10 @@ namespace BoletoNetCore
         public string RegistroArquivoRetorno { get; set; } = string.Empty;
 
         /// <summary>
-        /// Quantidade de dias para recebimento após o vencimento (exclusivo BB)
+        /// Quantidade de dias para recebimento após o vencimento (exclusivo BB / Caixa)
         /// Prazo permitido para recebimento do boleto após o vencimento. Após este prazo, o boleto será baixado.
-        /// Este registro deve ser utilizado somente quando o campo 21.2 (Carteira de Cobrança) – Comando – for igual a "01" - Registro de Título
-        /// Este Registro deve, obrigatoriamente, ser inserido após o Registro Detalhe Obrigatório correspondente ao título
+        /// (BB) Este registro deve ser utilizado somente quando o campo 21.2 (Carteira de Cobrança) – Comando – for igual a "01" - Registro de Título
+        /// (BB) Este Registro deve, obrigatoriamente, ser inserido após o Registro Detalhe Obrigatório correspondente ao título
         /// </summary>
         public int? DiasLimiteRecebimento { get; set; } = null;
         public int Distribuicao { get; set; } = 0;


### PR DESCRIPTION
Quando for gerado o arquivo de remessa utilizando um código do beneficiário de 7 digitos, é necessário incluir o valor "007" na posição 101 - 103

O prazo para baixa automática do boleto esta zerada, então defini o máximo "99" e deixando a possibilidade para preenchimento da variável "DiasLimiteRecebimento"  para personalização.