### PR TITLE
Propriedade Tag em Boleto

### DIFF
--- a/BoletoNetCore/Boleto/Boleto.cs
+++ b/BoletoNetCore/Boleto/Boleto.cs
@@ -226,6 +226,11 @@ namespace BoletoNetCore
         public ObservableCollection<GrupoDemonstrativo> Demonstrativos { get; } = new ObservableCollection<GrupoDemonstrativo>();
         public string ParcelaInformativo { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Atribua um objeto ao boleto para auxílio da implementação do boleto em diferentes sistemas
+        /// </summary>
+        public object Tag { get; set; }
+
         public void ValidarDados()
         {
             // Banco Obrigatório


### PR DESCRIPTION
A fim de que se possa atribuir um objeto na Tag do boleto, onde o desenvolvedor poderá atribuir objetos referentes ao seu sistema interno.