### PR TITLE
Alterações Juros/Multa/NossoNumero Sicoob

### DIFF
--- a/BoletoNetCore/Banco/Siscoob/BancoSicoob.CNAB240.cs
+++ b/BoletoNetCore/Banco/Siscoob/BancoSicoob.CNAB240.cs
@@ -210,20 +210,21 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0107, 002, 0, (int)boleto.EspecieDocumento, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 001, 0, boleto.Aceite, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0110, 008, 0, boleto.DataEmissao, '0');
-                if (boleto.ValorJurosDia == 0)
+                if (boleto.ValorJurosDia == 0 && boleto.PercentualJurosDia == 0)
                 {
                     // Sem Juros Mora
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0118, 001, 0, "0", '0');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0119, 008, 0, "0", '0');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0127, 015, 2, 0, '0');
-                }
-                else
-                {
+                } else {
                     // Com Juros Mora ($)
-                    reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0118, 001, 0, "1", '0');
+                    var codigoMora = (boleto.ValorJurosDia != 0) ? "1" : ((boleto.PercentualJurosDia != 0) ? "2" : "0");
+                    var valor = (boleto.ValorJurosDia != 0) ? boleto.ValorJurosDia : ((boleto.PercentualJurosDia != 0) ? boleto.PercentualJurosDia : 0);
+                    reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0118, 001, 0, codigoMora, '0');
                     reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0119, 008, 0, boleto.DataJuros, '0');
-                    reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0127, 015, 2, boleto.ValorJurosDia, '0');
+                    reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0127, 015, 2, valor, '0');
                 }
+
                 if (boleto.ValorDesconto == 0)
                 {
                     // Sem Desconto
@@ -321,13 +322,16 @@ namespace BoletoNetCore
                 var codMulta = "0";
                 if (boleto.ValorMulta > 0)
                     codMulta = "1";
-
+                else if (boleto.PercentualMulta > 0)
+                    codMulta = "2";
 
                 if (codMulta == "0")
                 {
                     // Se não tiver informação sobre Multa, não precisa gerar o registro.
                     return "";
                 }
+
+                var valorMulta = (codMulta == "1") ? boleto.ValorMulta : ((codMulta == "2") ? boleto.PercentualMulta : 0);
 
                 numeroRegistroGeral++;
                 TRegistroEDI reg = new TRegistroEDI();
@@ -346,7 +350,7 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0051, 015, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0066, 001, 0, codMulta, '0');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0067, 008, 0, boleto.DataMulta, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0075, 015, 2, boleto.ValorMulta, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0075, 015, 2, valorMulta, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0090, 010, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0100, 040, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0140, 040, 0, Empty, ' ');

--- a/BoletoNetCore/Banco/Siscoob/Carteiras/BancoSincoobCarteira1.cs
+++ b/BoletoNetCore/Banco/Siscoob/Carteiras/BancoSincoobCarteira1.cs
@@ -20,11 +20,11 @@ namespace BoletoNetCore
             if (beneficiario.ContaBancaria.TipoImpressaoBoleto == TipoImpressaoBoleto.Empresa & boleto.NossoNumero == Empty)
                 throw new Exception("Nosso Número não informado.");
             
-            // Nosso número não pode ter mais de 8 dígitos
-            if (boleto.NossoNumero.Length > 8)
-                throw new Exception("Nosso Número (" + boleto.NossoNumero + ") deve conter 8 dígitos.");
+            // Nosso número não pode ter mais de 7 dígitos
+            if (boleto.NossoNumero.Length > 7)
+                throw new Exception("Nosso Número (" + boleto.NossoNumero + ") deve conter 7 dígitos.");
 
-            boleto.NossoNumero = boleto.NossoNumero.PadLeft(8, '0');
+            boleto.NossoNumero = boleto.NossoNumero.PadLeft(7, '0');
 
             // Base para calcular DV: Agencia (4 caracteres) Código do Beneficiário com dígito (10 caracteres) Nosso Número (7 caracteres)
             var baseCalculoDV = $"{beneficiario.ContaBancaria.Agencia}{beneficiario.Codigo.PadLeft(9, '0')}{beneficiario.CodigoDV}{boleto.NossoNumero}";

--- a/BoletoNetCore/Banco/Siscoob/Carteiras/BancoSincoobCarteira1.cs
+++ b/BoletoNetCore/Banco/Siscoob/Carteiras/BancoSincoobCarteira1.cs
@@ -20,11 +20,11 @@ namespace BoletoNetCore
             if (beneficiario.ContaBancaria.TipoImpressaoBoleto == TipoImpressaoBoleto.Empresa & boleto.NossoNumero == Empty)
                 throw new Exception("Nosso Número não informado.");
             
-            // Nosso número não pode ter mais de 7 dígitos
-            if (boleto.NossoNumero.Length > 7)
-                throw new Exception("Nosso Número (" + boleto.NossoNumero + ") deve conter 7 dígitos.");
+            // Nosso número não pode ter mais de 8 dígitos
+            if (boleto.NossoNumero.Length > 8)
+                throw new Exception("Nosso Número (" + boleto.NossoNumero + ") deve conter 8 dígitos.");
 
-            boleto.NossoNumero = boleto.NossoNumero.PadLeft(7, '0');
+            boleto.NossoNumero = boleto.NossoNumero.PadLeft(8, '0');
 
             // Base para calcular DV: Agencia (4 caracteres) Código do Beneficiário com dígito (10 caracteres) Nosso Número (7 caracteres)
             var baseCalculoDV = $"{beneficiario.ContaBancaria.Agencia}{beneficiario.Codigo.PadLeft(9, '0')}{beneficiario.CodigoDV}{boleto.NossoNumero}";


### PR DESCRIPTION
Fiz algumas alterações no banco Sicoob.
1 - Ao gerar o segmento P do arquivo de remessa, não estava considerando o juros caso fosse por percentual, apenas por valor.
2 - Ao gerar o segmento R do arquivo de remessa, não estava considerando a multa caso fosse por percentual, apenas por valor.