### PR TITLE
Carteira 02 Bradesco

### DIFF
--- a/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteira02.cs
+++ b/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteira02.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using BoletoNetCore.Extensions;
+using static System.String;
+
+namespace BoletoNetCore
+{
+    [CarteiraCodigo("02")]
+    public class BancoBradescoCarteira02 : BancoBradescoCarteiraBase, ICarteira<BancoBradesco>
+    {
+        internal static Lazy<ICarteira<BancoBradesco>> Instance { get; } = new Lazy<ICarteira<BancoBradesco>>(() => new BancoBradescoCarteira02());
+
+        private BancoBradescoCarteira02()
+        {
+        }
+    }
+}

--- a/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteira05.cs
+++ b/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteira05.cs
@@ -5,43 +5,12 @@ using static System.String;
 namespace BoletoNetCore
 {
     [CarteiraCodigo("05")]
-    public class BancoBradescoCarteira05 : ICarteira<BancoBradesco>
+    public class BancoBradescoCarteira05 : BancoBradescoCarteiraBase, ICarteira<BancoBradesco>
     {
         internal static Lazy<ICarteira<BancoBradesco>> Instance { get; } = new Lazy<ICarteira<BancoBradesco>>(() => new BancoBradescoCarteira05());
 
         private BancoBradescoCarteira05()
         {
-
-        }
-
-        public void FormataNossoNumero(Boleto boleto)
-        {
-
-            // Nosso número não pode ter mais de 11 dígitos
-
-            if (IsNullOrWhiteSpace(boleto.NossoNumero) || boleto.NossoNumero == "00000000000")
-            {
-                // Banco irá gerar Nosso Número
-                boleto.NossoNumero = new String('0', 11);
-                boleto.NossoNumeroDV = "0";
-                boleto.NossoNumeroFormatado = "000/00000000000-0";
-            }
-            else
-            {
-                // Nosso Número informado pela empresa
-                if (boleto.NossoNumero.Length > 11)
-                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve conter 11 dígitos.");
-                boleto.NossoNumero = boleto.NossoNumero.PadLeft(11, '0');
-                boleto.NossoNumeroDV = (boleto.Carteira + boleto.NossoNumero).CalcularDVBradesco();
-                boleto.NossoNumeroFormatado = $"{boleto.Carteira.PadLeft(3, '0')}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
-            }
-
-        }
-
-        public string FormataCodigoBarraCampoLivre(Boleto boleto)
-        {
-            var contaBancaria = boleto.Banco.Beneficiario.ContaBancaria;
-            return $"{contaBancaria.Agencia}{boleto.Carteira}{boleto.NossoNumero}{contaBancaria.Conta}{"0"}";
         }
     }
 }

--- a/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteira09.cs
+++ b/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteira09.cs
@@ -5,43 +5,12 @@ using static System.String;
 namespace BoletoNetCore
 {
     [CarteiraCodigo("09")]
-    internal class BancoBradescoCarteira09 : ICarteira<BancoBradesco>
+    internal class BancoBradescoCarteira09 : BancoBradescoCarteiraBase, ICarteira<BancoBradesco>
     {
         internal static Lazy<ICarteira<BancoBradesco>> Instance { get; } = new Lazy<ICarteira<BancoBradesco>>(() => new BancoBradescoCarteira09());
 
         private BancoBradescoCarteira09()
         {
-
-        }
-
-        public void FormataNossoNumero(Boleto boleto)
-        {
-
-            // Nosso número não pode ter mais de 11 dígitos
-
-            if (IsNullOrWhiteSpace(boleto.NossoNumero) || boleto.NossoNumero == "00000000000")
-            {
-                // Banco irá gerar Nosso Número
-                boleto.NossoNumero = new String('0', 11);
-                boleto.NossoNumeroDV = "0";
-                boleto.NossoNumeroFormatado = "000/00000000000-0";
-            }
-            else
-            {
-                // Nosso Número informado pela empresa
-                if (boleto.NossoNumero.Length > 11)
-                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve conter 11 dígitos.");
-                boleto.NossoNumero = boleto.NossoNumero.PadLeft(11, '0');
-                boleto.NossoNumeroDV = (boleto.Carteira + boleto.NossoNumero).CalcularDVBradesco();
-                boleto.NossoNumeroFormatado = $"{boleto.Carteira.PadLeft(3, '0')}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
-            }
-
-        }
-
-        public string FormataCodigoBarraCampoLivre(Boleto boleto)
-        {
-            var contaBancaria = boleto.Banco.Beneficiario.ContaBancaria;
-            return $"{contaBancaria.Agencia}{boleto.Carteira}{boleto.NossoNumero}{contaBancaria.Conta}{"0"}";
         }
     }
 }

--- a/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteiraBase.cs
+++ b/BoletoNetCore/Banco/Bradesco/Carteiras/BancoBradescoCarteiraBase.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using BoletoNetCore.Extensions;
+using static System.String;
+
+namespace BoletoNetCore
+{
+    public abstract class BancoBradescoCarteiraBase
+    {
+        public virtual void FormataNossoNumero(Boleto boleto)
+        {
+
+            // Nosso número não pode ter mais de 11 dígitos
+
+            if (IsNullOrWhiteSpace(boleto.NossoNumero) || boleto.NossoNumero == "00000000000")
+            {
+                // Banco irá gerar Nosso Número
+                boleto.NossoNumero = new String('0', 11);
+                boleto.NossoNumeroDV = "0";
+                boleto.NossoNumeroFormatado = "000/00000000000-0";
+            }
+            else
+            {
+                // Nosso Número informado pela empresa
+                if (boleto.NossoNumero.Length > 11)
+                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve conter 11 dígitos.");
+                boleto.NossoNumero = boleto.NossoNumero.PadLeft(11, '0');
+                boleto.NossoNumeroDV = (boleto.Carteira + boleto.NossoNumero).CalcularDVBradesco();
+                boleto.NossoNumeroFormatado = $"{boleto.Carteira.PadLeft(3, '0')}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
+            }
+
+        }
+
+        public virtual string FormataCodigoBarraCampoLivre(Boleto boleto)
+        {
+            var contaBancaria = boleto.Banco.Beneficiario.ContaBancaria;
+            return $"{contaBancaria.Agencia}{boleto.Carteira}{boleto.NossoNumero}{contaBancaria.Conta}{"0"}";
+        }
+    }
+}

--- a/BoletoNetCore/Banco/Cecred/BancoCecred.CNAB400.cs
+++ b/BoletoNetCore/Banco/Cecred/BancoCecred.CNAB400.cs
@@ -62,11 +62,13 @@ namespace BoletoNetCore
                 tregistroEdi.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 180, 13, 2, boleto.ValorDesconto, '0'));
                 tregistroEdi.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 193, 13, 0, "000000", '0'));
                 tregistroEdi.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 206, 13, 2, boleto.ValorAbatimento, '0'));
-                string str3 = "02";
+
+                // variavel causando warning pois nunca é utilizada (apenas atribuida em dois locais)
+                //string str3 = "02";
                 string str4 = "02";
                 num = Beneficiario.CPFCNPJ.Length;
-                if (num.Equals(11))
-                    str3 = "01";
+                //if (num.Equals(11))
+                //    str3 = "01";
                 num = boleto.Pagador.CPFCNPJ.Length;
                 if (num.Equals(11))
                     str4 = "01";
@@ -172,7 +174,7 @@ namespace BoletoNetCore
                 throw new Exception("Erro ao ler detalhe do arquivo de RETORNO / CNAB 400.", ex);
             }
         }
-        
+
         private string DescricaoOcorrenciaCnab400(string codigo)
         {
             switch (codigo)


### PR DESCRIPTION
refactoring na implementacao das carteiras do bradesco para remover duplicidade de codigo; no caso em questao, as carteiras 05 e 09 existentes, possuiam o mesmo codigo duplicado, foi criado uma classe base abstrata para ser herdado por elas, alem disso, adicionado a carteira 02 nos mesmos moldes das outras duas