### PR TITLE
CNAB 240 - Banco do Brasil

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
@@ -47,6 +47,7 @@ namespace BoletoNetCore
 
             arquivoRetorno.Banco.Beneficiario.ContaBancaria = new ContaBancaria();
 
+            arquivoRetorno.Banco.Beneficiario.Codigo = Utils.ToInt32(registro.Substring(32, 9)).ToString();
             arquivoRetorno.Banco.Beneficiario.ContaBancaria.Agencia = registro.Substring(52, 5);
             arquivoRetorno.Banco.Beneficiario.ContaBancaria.DigitoAgencia = registro.Substring(57, 1);
             arquivoRetorno.Banco.Beneficiario.ContaBancaria.Conta = registro.Substring(58, 12);
@@ -119,7 +120,8 @@ namespace BoletoNetCore
                 string str = registro.Substring(133, 15);
                 boleto.Pagador.CPFCNPJ = str.Substring(str.Length - 14, 14);
                 boleto.Pagador.Nome = registro.Substring(148, 40);
-
+                if (boleto.Pagador.Nome.Trim() == Utils.FormatCode("0", boleto.Pagador.Nome.Trim().Length))
+                    boleto.Pagador.Nome = "";
 
                 // Registro Retorno
                 boleto.RegistroArquivoRetorno = boleto.RegistroArquivoRetorno + registro + Environment.NewLine;

--- a/BoletoNetCore/Util/Cnab.cs
+++ b/BoletoNetCore/Util/Cnab.cs
@@ -31,6 +31,8 @@ namespace BoletoNetCore
                     return "Confirmação do Recebimento do Cancelamento do Desconto";
                 case "09":
                     return "Baixa";
+                case "11":
+                    return "Título em Carteira (em ser)";
                 case "12":
                     return "Confirmação Recebimento Instrução de Abatimento";
                 case "13":


### PR DESCRIPTION
- Ajuste para preencher o código do beneficiário ao ler retorno CNAB240.
- Ajuste para limpar o nome do pagador quando ele for tudo 00000... Pelo que vi o Banco do Brasil não retorna os dados do pagador no arquivo de retorno CNAB240.
- Adicionado código de movimento retorno 11 - Títulos em Carteira (em ser),