### PR TITLE
arrumado o metodo CompletarHeaderRetornoCNAB400 para ser um para cada…

### DIFF
--- a/BoletoNetCore/Banco/BancoFebraban.CNAB400.cs
+++ b/BoletoNetCore/Banco/BancoFebraban.CNAB400.cs
@@ -12,18 +12,7 @@ namespace BoletoNetCore
         ///
         public virtual void CompletarHeaderRetornoCNAB400(string registro)
         {
-            this.Beneficiario.ContaBancaria = new ContaBancaria();
-            this.Beneficiario.ContaBancaria.Agencia = registro.Substring(25, this.TamanhoAgencia);
-
-            var conta = registro.Substring(30, this.TamanhoConta).Trim();
-            this.Beneficiario.ContaBancaria.Conta = conta.Substring(0, conta.Length - 1);
-            this.Beneficiario.ContaBancaria.DigitoConta = conta.Substring(conta.Length - 1, 1);
-
-            // 01 - cpf / 02 - cnpj
-            if (registro.Substring(1, 2) == "01")
-                this.Beneficiario.CPFCNPJ = registro.Substring(6, 11);
-            else
-                this.Beneficiario.CPFCNPJ = registro.Substring(3, 14);
+            //implementar cada um especificamente! Pois muda o modelo de cada banco...
         }
 
         public virtual void LerHeaderRetornoCNAB400(string registro)

--- a/BoletoNetCore/Banco/Bradesco/BancoBradesco.CNAB400.cs
+++ b/BoletoNetCore/Banco/Bradesco/BancoBradesco.CNAB400.cs
@@ -384,6 +384,20 @@ namespace BoletoNetCore
         {
         }
 
-        
+        public override void CompletarHeaderRetornoCNAB400(string registro)
+        {
+            this.Beneficiario.ContaBancaria = new ContaBancaria();
+            this.Beneficiario.ContaBancaria.Agencia = registro.Substring(25, this.TamanhoAgencia);
+
+            var conta = registro.Substring(30, this.TamanhoConta).Trim();
+            this.Beneficiario.ContaBancaria.Conta = conta.Substring(0, conta.Length - 1);
+            this.Beneficiario.ContaBancaria.DigitoConta = conta.Substring(conta.Length - 1, 1);
+
+            // 01 - cpf / 02 - cnpj
+            if (registro.Substring(1, 2) == "01")
+                this.Beneficiario.CPFCNPJ = registro.Substring(6, 11);
+            else
+                this.Beneficiario.CPFCNPJ = registro.Substring(3, 14);
+        }
     }
 }


### PR DESCRIPTION
bug criado com pull #192 

Os bancos não seguem o mesmo padrão de campos de beneficiário e o método retornava erro ao ler linha de arquivo de retorno de alguns bancos!

Arrumado o método **CompletarHeaderRetornoCNAB400** na interface **IBanco**, retirando ele de todos os bancos ao mesmo tempo e especificando apenas no Bradesco como o @marcianobandeira  tinha indicado no pull #192

Um pull request tambem já foi feito para o Itau anteriormente arrumando o mesmo problema...

_É bom entender que como são campos novos que anteriormente não eram recuperados do arquivo de retorno, e que cada banco tem seu manual/padrão, caso alguém queira esses dados, implementa o método **CompletarHeaderRetorno**. O Padrão deve ser hoje a não implementação do mesmo para todos os bancos, assim não quebramos ninguém :)_

