### PR TITLE
Beneficiário final - Convenção entre Instituições do Sistema Financeiro Nacional FB-0061/202

### DIFF
--- a/BoletoNetCore/BoletoImpressao/Parts/ReciboBeneficiarioParte10.html
+++ b/BoletoNetCore/BoletoImpressao/Parts/ReciboBeneficiarioParte10.html
@@ -1,6 +1,6 @@
 ﻿<table class="w666 ctN">
     <tr>
-        <td class="pL6  w409">Pagador / Avalista <b class="cpN">@AVALISTA</b></td>
+        <td class="pL6  w409">Beneficiário Final<b class="cpN">@AVALISTA</b></td>
         <td class="w250 Ar">Autenticação mecânica - <b class="cpN">Ficha de Compensação</b></td>
     </tr>
     <tr class="h13"><td colspan="3" /></tr>


### PR DESCRIPTION
Alteração da nomenclatura de Pagador Avalista para Beneficiário final - (Obs: No boleto físico, o termo Avalista foi substituído por Beneficiário final, conforme Convenção entre Instituições do Sistema Financeiro Nacional FB-0061/2021"). 

**Essa mudança foi necessária após eu homologar com banco safra carteira 1, pediram essa modificação.**

![image](https://user-images.githubusercontent.com/14843499/208997503-bdfde1c1-51a8-47e9-933a-c00ecf81bfef.png)

![image](https://user-images.githubusercontent.com/14843499/208997553-569b5461-58f5-49e9-a347-bd05120a2f6e.png)

![image](https://user-images.githubusercontent.com/14843499/208997621-6dd60ee3-a19e-4742-b35d-5b3f104e2fb1.png)

Links Externos:
https://www.projetoacbr.com.br/forum/topic/64334-problemas-para-homologar-boleto-safra-fastreport/