### PR TITLE
arrumado erro de cpf/cnpj vazio dando erro ao formatar

### DIFF
--- a/BoletoNetCore/Util/Utils.cs
+++ b/BoletoNetCore/Util/Utils.cs
@@ -89,12 +89,15 @@ namespace BoletoNetCore
         /// <returns></returns>
         internal static string FormataCPFCPPJ(string value)
         {
-            if (value.Trim().Length == 11)
-                return FormataCPF(value);
-            if (value.Trim().Length == 14)
-                return FormataCNPJ(value);
-
-            throw new Exception($"O CPF ou CNPJ: {value} é inválido.");
+            switch (value.Trim().Length)
+            {
+                case 11:
+                    return FormataCPF(value);
+                case 14:
+                    return FormataCNPJ(value);
+                default:
+                    return value;
+            }
         }
 
         /// <summary>
@@ -106,7 +109,7 @@ namespace BoletoNetCore
         {
             try
             {
-                return $"{cpf.Substring(0, 3)}.{cpf.Substring(3, 3)}.{cpf.Substring(6, 3)}-{cpf.Substring(9, 2)}";
+                return cpf != null && cpf.Length == 11 ? $"{cpf.Substring(0, 3)}.{cpf.Substring(3, 3)}.{cpf.Substring(6, 3)}-{cpf.Substring(9, 2)}" : cpf;
             }
             catch
             {
@@ -123,7 +126,7 @@ namespace BoletoNetCore
         {
             try
             {
-                return $"{cnpj.Substring(0, 2)}.{cnpj.Substring(2, 3)}.{cnpj.Substring(5, 3)}/{cnpj.Substring(8, 4)}-{cnpj.Substring(12, 2)}";
+                return cnpj != null && cnpj.Length == 14 ? $"{cnpj.Substring(0, 2)}.{cnpj.Substring(2, 3)}.{cnpj.Substring(5, 3)}/{cnpj.Substring(8, 4)}-{cnpj.Substring(12, 2)}" : cnpj;
             }
             catch
             {
@@ -140,7 +143,7 @@ namespace BoletoNetCore
         {
             try
             {
-                return $"{cep.Substring(0, 2)}{cep.Substring(2, 3)}-{cep.Substring(5, 3)}";
+                return cep != null && cep.Length == 8 ? $"{cep.Substring(0, 2)}{cep.Substring(2, 3)}-{cep.Substring(5, 3)}" : cep;
             }
             catch
             {

--- a/BoletoNetCore/Util/Utils.cs
+++ b/BoletoNetCore/Util/Utils.cs
@@ -89,6 +89,11 @@ namespace BoletoNetCore
         /// <returns></returns>
         internal static string FormataCPFCPPJ(string value)
         {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
             switch (value.Trim().Length)
             {
                 case 11:


### PR DESCRIPTION
Causando erro..
![image](https://user-images.githubusercontent.com/14843499/211966605-dc0832ad-04ee-45c9-8469-607c22614f1e.png)
O correto é se for vazio, ele não formatar e ignorar (retornando ele mesmo).