### PR TITLE
Boleto Banco do Brasil Recusado quando há desconto

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
@@ -424,10 +424,13 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0016, 002, 0, boleto.CodigoMovimentoRetorno, '0');
 
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, boleto.ValorDesconto == 0 ? "0" : "1", '0');
+                // Campo Desconto 3 no Boleto - Como não existe a previsão do banco na classe, conforme o manual, codigo deve ser zerado
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 008, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0027, 015, 2, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0042, 001, 0, boleto.ValorDesconto == 0 ? "0" : "1", '0');
+
+                // Campo Desconto 3 no Boleto - Como não existe a previsão do banco na classe, conforme o manual, codigo deve ser zerado
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0042, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0043, 008, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0051, 015, 2, "0", '0');
 


### PR DESCRIPTION
ao gerar uma remessa de boleto com desconto no banco do brasil, está sendo recusado devido aos campos Codigo do Desconto 2 e Codigo do Desconto 3, que estavam sendo tratados conforme a propriedade ValorDesconto, mas como os valores destes campos sao passados zerados na remessa, o código deve ser zero tambem, conforme o manual do banco