### PR TITLE
Adicionada Leitura do Header Retorno CNAB400 SICREDI.

### DIFF
--- a/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
@@ -417,6 +417,9 @@ namespace BoletoNetCore
             {
                 if (registro.Substring(0, 9) != "02RETORNO")
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
+
+                this.Beneficiario = new Beneficiario();
+                this.Beneficiario.Codigo = registro.Substring(26, 5);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Leitura do Header CNAB400 da Caixa estava somente validando tipo de arquivo.
- Adicionado controle para pegar dados do Header conforme manual da SICREDI.
- Somente o Código do Cedente. (Mas já é uma informação importante para fazer validação de dados se o arquivo remessa é correspondente ao banco de importação em questão).