### PR TITLE
Inclusão de parâmetro no metodo GerarBoletos para inclusão de QrCode nos boletos

### DIFF
--- a/BoletoNetCore.Pdf/BoletoNetCorePdfProxy.cs
+++ b/BoletoNetCore.Pdf/BoletoNetCorePdfProxy.cs
@@ -6,7 +6,7 @@ namespace BoletoNetCore.Pdf
 {
     public class BoletoNetCorePdfProxy : BoletoNetCoreProxy
     {
-        public override bool GerarBoletos(string nomeArquivo, ref string mensagemErro, string pixString)
+        public override bool GerarBoletos(string nomeArquivo, ref string mensagemErro, string pixString = null)
         {
             
             mensagemErro = "";

--- a/BoletoNetCore.Pdf/BoletoNetCorePdfProxy.cs
+++ b/BoletoNetCore.Pdf/BoletoNetCorePdfProxy.cs
@@ -6,7 +6,7 @@ namespace BoletoNetCore.Pdf
 {
     public class BoletoNetCorePdfProxy : BoletoNetCoreProxy
     {
-        public override bool GerarBoletos(string nomeArquivo, ref string mensagemErro)
+        public override bool GerarBoletos(string nomeArquivo, ref string mensagemErro, string pixString)
         {
             
             mensagemErro = "";

--- a/BoletoNetCore.Testes/ExemploClasseProxy.cs
+++ b/BoletoNetCore.Testes/ExemploClasseProxy.cs
@@ -69,7 +69,7 @@ namespace BoletoNetCore.Testes
             Assert.AreEqual(true, retorno, "GerarRemessa: " + mensagemErro);
 
             // Para gerar o arquivo PDF
-            classeProxy.GerarBoletos(nomePasta + @"ClasseProxy_Boleto.Pdf", ref mensagemErro);
+            classeProxy.GerarBoletos(nomePasta + @"ClasseProxy_Boleto.Pdf", ref mensagemErro, null);
             Assert.AreEqual(true, retorno, "GerarBoletos: " + mensagemErro);
 
         }

--- a/BoletoNetCore.Testes/ExemploClasseProxy.cs
+++ b/BoletoNetCore.Testes/ExemploClasseProxy.cs
@@ -69,7 +69,7 @@ namespace BoletoNetCore.Testes
             Assert.AreEqual(true, retorno, "GerarRemessa: " + mensagemErro);
 
             // Para gerar o arquivo PDF
-            classeProxy.GerarBoletos(nomePasta + @"ClasseProxy_Boleto.Pdf", ref mensagemErro, null);
+            classeProxy.GerarBoletos(nomePasta + @"ClasseProxy_Boleto.Pdf", ref mensagemErro);
             Assert.AreEqual(true, retorno, "GerarBoletos: " + mensagemErro);
 
         }

--- a/BoletoNetCore/BoletoNetCoreProxy.cs
+++ b/BoletoNetCore/BoletoNetCoreProxy.cs
@@ -511,7 +511,7 @@ namespace BoletoNetCore
                 return false;
             }
         }
-        public virtual bool GerarBoletos(string nomeArquivo, ref string mensagemErro)
+        public virtual bool GerarBoletos(string nomeArquivo, ref string mensagemErro, string pixString = null)
         {
             mensagemErro = "";
             try
@@ -549,7 +549,7 @@ namespace BoletoNetCore
                     };
                     {
                         html.Append("<div style=\"page-break-after: always;\">");
-                        html.Append(imprimeBoleto.MontaHtmlEmbedded());
+                        html.Append(imprimeBoleto.MontaHtmlEmbedded(pixString: pixString));
                         html.Append("</div>");
                     }
                 }
@@ -659,7 +659,7 @@ namespace BoletoNetCore
                 boletos.Clear();
 
                 var arquivoRetorno = new ArquivoRetorno(boletos.Banco, (TipoArquivo)formatoArquivo);
-                
+
                 boletos = arquivoRetorno.LerArquivoRetorno(nomeArquivo);
                 return true;
             }
@@ -686,7 +686,7 @@ namespace BoletoNetCore
                 }
             }
         }
-        
+
     }
 
 }


### PR DESCRIPTION
Inclusão do parâmetro opcional **_pixString_** no método **_GerarBoletos_** para permitir a geração de boletos híbridos com QRCode Pix.

` public virtual bool GerarBoletos(string nomeArquivo, ref string mensagemErro, string pixString = null)`

Exemplo do boleto gerado:
![image](https://github.com/BoletoNet/BoletoNetCore/assets/50370623/6f25cf40-31f7-4b4e-b994-afb9faf5caf3)

> Obs.: Os dados da imagem acima foram ocultados por questões confidenciais.

