### PR TITLE
Import pacote NReco PDF versão mais atual com suporte a net standard

### DIFF
--- a/BoletoNetCore.Pdf/BoletoImpressao/BoletoBancarioPdf.cs
+++ b/BoletoNetCore.Pdf/BoletoImpressao/BoletoBancarioPdf.cs
@@ -14,5 +14,10 @@ namespace BoletoNetCore.Pdf.BoletoImpressao
 
 
         }
+
+        public byte[] MontaBytesPDFLegacy(bool convertLinhaDigitavelToImage = false, string urlImagemLogoBeneficiario = null)
+        {
+            return (new NReco.PdfGenerator.HtmlToPdfConverter()).GeneratePdf(MontaHtmlEmbedded(convertLinhaDigitavelToImage, true, urlImagemLogoBeneficiario));
+        }
     }
 }

--- a/BoletoNetCore.Pdf/BoletoNetCore.Pdf.csproj
+++ b/BoletoNetCore.Pdf/BoletoNetCore.Pdf.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Wkhtmltopdf.NetCore" Version="1.1.3" />
+	<PackageReference Include="NReco.PdfGenerator" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ CNAB400, CNAB240 e OnlineRest (**Procuramos Implementadores**)
 Este projeto possui algumas diferenças relevantes em relação ao Boleto2Net que podem quebrar o seu código:
 - Retorno de Arquivos CNAB geram **CodMovimentoRetorno** no Lugar de **CodOcorrencia**.
 - Se você quer usar a impressão em PDF, use o **BoletoNetCorePdfProxy** e não **BoletoNetCoreProxy**.
+- Para imprimir PDF usando o pacote NReco igual ao Boleto2Net, chamar o método MontaBytesPDFLegacy()
 - Para a impressão em PDF, também é necessário a instalação do pacote [BoletoNetCore.Pdf](https://www.nuget.org/packages/BoletoNetCore.PDF/).
 - Este projeto não usa **System.Web** então, não existem componentes manipuláveis para WebForms para o Editor do VS. 
 - Cedente e Sacado foram substituidos em todo o projeto pelos termos atuais **Beneficiario** e **Pagador**


### PR DESCRIPTION
Estou migrando agora pro BoletNetCore, vim do Boleto2Net, que usa o pacote NReco PDF. Esse pacote não tinha suporte a .net standard até janeiro deste ano. O que mudou.

Esse era um dos grandes problemas que eu tinha quando eu fiz um fork do boleto2net e implementei multitarget com .net core no mesmo usando um arquivo report do fast report. (Inclusive minha PR tá lá desde o ano passado sem ter recebido a devida atenção). 

Percebi que a comunidade nesse projeto aqui é mais ativa e estava esperando a oportunidade certa para migrar. A necessidade apareceu e eu migrei. Porém essa forma de gerar pdf de boleto não tá funcionando direito sem uma certa burocracia.

O projeto NReco pdf está com uma versão com suporte a .net standard. Para não atrapalhar o funcionamento de quem já usa o método que esta em andamento atualmente, eu criei um méthodo chamado `MontaBytesPdfLegacy()` que é identico ao antigo MontaBytesPdf do Boleto2Net.

Meu projeto é target net48 no windows e funcionou legal. Não testei em sistemas mac ou linux com .net core por não ter a disponibilidade no momento e por falta de tempo também. 