### PR TITLE
A propriedade código de barras pode aceitar valor.

### DIFF
--- a/BoletoNetCore/Boleto/CodigoBarra.cs
+++ b/BoletoNetCore/Boleto/CodigoBarra.cs
@@ -5,6 +5,8 @@ namespace BoletoNetCore
 {
     public class CodigoBarra
     {
+        string _codigoDeBarras;
+
         /// <summary>
         /// Representação numérica do Código de Barras, composto por 44 posições
         ///    01 a 03 - 3 - Identificação  do  Banco
@@ -18,6 +20,14 @@ namespace BoletoNetCore
         {
             get
             {
+                // Com o advento das APIs "developers" dos bancos para a cobrança, muitos devolvem o código de barras como ele deve ser impresso no boleto.
+                // Com isso, não há a necessidade de se criar o código de barras uma vez que ele foi informado
+                // Marcelo - https://unimake.com.br/ 
+                if(!string.IsNullOrWhiteSpace(_codigoDeBarras))
+                {
+                    return _codigoDeBarras;
+                }
+
                 string codigoSemDv = string.Format("{0}{1}{2}{3}{4}",
                                                       CodigoBanco,
                                                       Moeda,
@@ -28,7 +38,10 @@ namespace BoletoNetCore
                                         codigoSemDv.Left(4),
                                         DigitoVerificador,
                                         codigoSemDv.Right(39));
+
+
             }
+            set => _codigoDeBarras = value;
         }
 
         /// <summary>
@@ -80,16 +93,16 @@ namespace BoletoNetCore
 
                 // Calcula Dígito Verificador do Código de Barras
                 int pesoMaximo = 9, soma = 0, peso = 2;
-                for (int i = (codigoSemDv.Length - 1); i >= 0; i--)
+                for(int i = (codigoSemDv.Length - 1); i >= 0; i--)
                 {
                     soma = soma + (Convert.ToInt32(codigoSemDv.Substring(i, 1)) * peso);
-                   
+
                     peso = peso == pesoMaximo ? 2 : peso + 1;
-                   
+
                 }
                 var resto = (soma % 11);
 
-                if (resto <= 1 || resto > 9)
+                if(resto <= 1 || resto > 9)
                     return "1";
 
                 return (11 - resto).ToString();

--- a/BoletoNetCore/BoletoNetCore.csproj
+++ b/BoletoNetCore/BoletoNetCore.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Com o advento das APIs "developers" dos bancos para a cobrança, muitos devolvem o código de barras como ele deve ser impresso no boleto.
Com isso, não há a necessidade de se criar o código de barras uma vez que ele foi informado