### PR TITLE
Conta do Siccob pode ter ate 12 dígitos

### DIFF
--- a/BoletoNetCore/Banco/Sicoob/BancoSicoob.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicoob/BancoSicoob.CNAB400.cs
@@ -73,7 +73,7 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0004, 014, 0, boleto.Banco.Beneficiario.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 004, 0, boleto.Banco.Beneficiario.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0022, 001, 0, boleto.Banco.Beneficiario.ContaBancaria.DigitoAgencia, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0023, 008, 0, boleto.Banco.Beneficiario.ContaBancaria.Conta, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0023, 008, 0, boleto.Banco.Beneficiario.ContaBancaria.Conta.Substring(boleto.Banco.Beneficiario.ContaBancaria.Conta.Length - 8, 8), '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0031, 001, 0, boleto.Banco.Beneficiario.ContaBancaria.DigitoConta, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0032, 006, 0, "000000", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0038, 025, 0, boleto.NumeroControleParticipante, ' ');

--- a/BoletoNetCore/Banco/Sicoob/BancoSicoob.cs
+++ b/BoletoNetCore/Banco/Sicoob/BancoSicoob.cs
@@ -28,7 +28,7 @@ namespace BoletoNetCore
             if (Beneficiario.CodigoDV == Empty)
                 throw new Exception($"Dígito do código do beneficiário ({codigoBeneficiario}) não foi informado.");
 
-            contaBancaria.FormatarDados("PAGÁVEL EM QUALQUER BANCO ATÉ A DATA DE VENCIMENTO.", "", "", 8);
+            contaBancaria.FormatarDados("PAGÁVEL EM QUALQUER BANCO ATÉ A DATA DE VENCIMENTO.", "", "", 12);
 
             Beneficiario.Codigo = codigoBeneficiario.Length <= 6 ? codigoBeneficiario.PadLeft(6, '0') : throw BoletoNetCoreException.CodigoBeneficiarioInvalido(codigoBeneficiario, 6);
 


### PR DESCRIPTION
o Cnab 400 esta sendo descontinuado e a conta esta limitada a 8 dígitos sendo que o Cnab240 tem ate 12 dígitos sendo assim alterei a quantidade limite para 12