### PR TITLE
fix: na chamada do método `GerarMensagemRemessa`

### DIFF
--- a/BoletoNetCore/Arquivo/ArquivoRemessa.cs
+++ b/BoletoNetCore/Arquivo/ArquivoRemessa.cs
@@ -76,9 +76,10 @@ namespace BoletoNetCore
                     strline = FormataLinhaArquivoCNAB(strline, tamanhoRegistro);
                     arquivoRemessa.WriteLine(strline);
 
-                    if (boleto.Banco.GerarMensagemRemessa(TipoArquivo, boleto, ref numeroRegistroGeral) != null)
+                    var mensagemRemessa = boleto.Banco.GerarMensagemRemessa(TipoArquivo, boleto, ref numeroRegistroGeral);
+                    if (mensagemRemessa != null)
                     {
-                        strline = boleto.Banco.GerarMensagemRemessa(TipoArquivo, boleto, ref numeroRegistroGeral);
+                        strline = mensagemRemessa;
                         strline = FormataLinhaArquivoCNAB(strline, tamanhoRegistro);
                         arquivoRemessa.WriteLine(strline);
                     }


### PR DESCRIPTION
O Erro estava na execução duplicada do método `GerarMensagemRemessa` sendo gerado a numeração de linha com falha 

![image](https://github.com/BoletoNet/BoletoNetCore/assets/4265060/3112e9a8-8b4f-49c5-85b8-dee95b442174)

![image](https://github.com/BoletoNet/BoletoNetCore/assets/4265060/be02dcda-2460-44ea-adb4-9fa9d1399681)

