### PR TITLE
Ajustes nos campos 08.3R e 11.3R para Banco do Brasil

### DIFF
--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB240.cs
@@ -438,8 +438,15 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0016, 002, 0, boleto.CodigoMovimentoRetorno, '0');
                 if (boleto.ValorDesconto2 == 0)
                 {
-                    // Sem Desconto 2
-                    reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, "0", '0');
+                    // Sem Desconto 2 -- BANCO DO BRASIL EXIGE QUE O CODIGO DO DESCONTO SEJA IGUAL AO CODIGO USADO DESCONTO
+                    if (boleto.ValorDesconto == 0)
+                    {
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, "0", '0');
+                    }
+                    else
+                    {
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, "1", '0');
+                    }
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 008, 0, "0", '0');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0027, 015, 0, "0", '0');
                 }
@@ -452,8 +459,15 @@ namespace BoletoNetCore
                 }
                 if (boleto.ValorDesconto3 == 0)
                 {
-                    // Sem Desconto 3
-                    reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0042, 001, 0, "0", '0');
+                    // Sem Desconto 3 -- BANCO DO BRASIL EXIGE QUE O CODIGO DO DESCONTO SEJA IGUAL AO CODIGO USADO DESCONTO
+                    if (boleto.ValorDesconto == 0)
+                    {
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0042, 001, 0, "0", '0');
+                    }
+                    else
+                    {
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0042, 001, 0, "1", '0');
+                    }
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0043, 008, 0, "0", '0');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0051, 015, 0, "0", '0');
                 }


### PR DESCRIPTION
quando só existe o desconto 1 no campo 30.3P, deve repetir o mesmo código nos campos 08.3R e 11.3R.
OBS: Hoje pelo que vi na parte do BB, o componente só trabalha com o desconto em valor fixo por isso está arbitrado o codigo do desconto = "1".  Para trabalhar com descontos percentuais será necessário novo ajuste.
![image](https://github.com/BoletoNet/BoletoNetCore/assets/18599643/23f34cd2-20d9-41aa-8659-7086a92b0ac9)
