### PR TITLE
Ajuste do campo "Parcela" no pdf

### DIFF
--- a/BoletoNetCore.QuestPdf/Carne/ReciboLateralCarne.cs
+++ b/BoletoNetCore.QuestPdf/Carne/ReciboLateralCarne.cs
@@ -1,9 +1,5 @@
-using BoletoNetCore;
-using QuestPDF.Infrastructure;
 using QuestPDF.Fluent;
-using Microsoft.Extensions.FileProviders;
-using System.Reflection;
-using System.IO;
+using QuestPDF.Infrastructure;
 
 namespace BoletoNetCore.QuestPdf
 {
@@ -28,7 +24,7 @@ namespace BoletoNetCore.QuestPdf
                     row.RelativeColumn().BorderRight(BoletoPdfConstants.BorderSize).Stack(st =>
                     {
                         st.Item().Text("Parcela", BoletoPdfConstants.LabelStyle);
-                        st.Item().Text($"001 / 001", BoletoPdfConstants.NormalFieldStyle); // todo
+                        st.Item().Text(this.boleto.ParcelaInformativo, BoletoPdfConstants.NormalFieldStyle); // todo
                     });
 
                     row.RelativeColumn().Stack(st =>


### PR DESCRIPTION
Ajuste no campo "Parcela" na geração de PDF para usar o campo "parcelaInformativo" do boleto ao invés de usar o valor fixo "001 /001", semelhante ao que é feito para Html.