### PR TITLE
Inclui novo TipoEspecieDocumento

### DIFF
--- a/BoletoNetCore/Enums/TipoEspecieDocumento.cs
+++ b/BoletoNetCore/Enums/TipoEspecieDocumento.cs
@@ -101,6 +101,9 @@
         /// <summary>Boleto Proposta</summary>
         BP = 32,
 
+        /// <summary>Diversos</summary>
+        DV = 33,
+
         /// <summary>Outros</summary>
         OU = 99
     }


### PR DESCRIPTION
O banco Itau define a especie documento 99 que geralmente é outros (OU) como diversos (DV). Portanto para que o campo especie documento possa ter o valor DV utilizado no Itau, estou adicionando esse novo valor de enum.