### PR TITLE
Implementado leitura de segmento 4 para layout 400.

### DIFF
--- a/BoletoNetCore/Arquivo/ArquivoRetorno.cs
+++ b/BoletoNetCore/Arquivo/ArquivoRetorno.cs
@@ -218,6 +218,9 @@ namespace BoletoNetCore
                 case "1":
                     b.LerDetalheRetornoCNAB400Segmento1(ref boleto, registro);
                     break;
+                case "4":
+                    b.LerDetalheRetornoCNAB400Segmento4(ref boleto, registro);
+                    break;
                 case "7":
                     b.LerDetalheRetornoCNAB400Segmento7(ref boleto, registro);
                     break;

--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB400.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB400.cs
@@ -228,8 +228,12 @@ namespace BoletoNetCore
                 throw new Exception("Erro ao ler HEADER do arquivo de RETORNO / CNAB 400.", ex);
             }
         }
-
         public void LerDetalheRetornoCNAB400Segmento1(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();
         }

--- a/BoletoNetCore/Banco/BancoInter/BancoInter.CNAB400.cs
+++ b/BoletoNetCore/Banco/BancoInter/BancoInter.CNAB400.cs
@@ -301,9 +301,14 @@ namespace BoletoNetCore
         {
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
-            
+            throw new NotImplementedException();
         }
 
         private string DescricaoMovimentoRetornoCnab400(string codigo, string registro)

--- a/BoletoNetCore/Banco/Banrisul/BancoBanrisul.CNAB400.cs
+++ b/BoletoNetCore/Banco/Banrisul/BancoBanrisul.CNAB400.cs
@@ -390,6 +390,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Bradesco/BancoBradesco.CNAB400.cs
+++ b/BoletoNetCore/Banco/Bradesco/BancoBradesco.CNAB400.cs
@@ -75,6 +75,12 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            boleto.QRCode = registro.Substring(28, 77);
+            boleto.TxId = registro.Substring(105, 35);
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Bradesco/BancoBradesco.cs
+++ b/BoletoNetCore/Banco/Bradesco/BancoBradesco.cs
@@ -13,7 +13,7 @@ namespace BoletoNetCore
             Codigo = 237;
             Nome = "Bradesco";
             Digito = "2";
-            IdsRetornoCnab400RegistroDetalhe = new List<string> { "1" };
+            IdsRetornoCnab400RegistroDetalhe = new List<string> { "1", "4"};
             RemoveAcentosArquivoRemessa = true;
         }
 

--- a/BoletoNetCore/Banco/Caixa/BancoCaixa.CNAB400.cs
+++ b/BoletoNetCore/Banco/Caixa/BancoCaixa.CNAB400.cs
@@ -207,6 +207,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Cecred/BancoCecred.CNAB400.cs
+++ b/BoletoNetCore/Banco/Cecred/BancoCecred.CNAB400.cs
@@ -258,6 +258,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/CrediSis/BancoCrediSIS.CNAB400.cs
+++ b/BoletoNetCore/Banco/CrediSis/BancoCrediSIS.CNAB400.cs
@@ -258,6 +258,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Daycoval/BancoDaycoval.CNAB400.cs
+++ b/BoletoNetCore/Banco/Daycoval/BancoDaycoval.CNAB400.cs
@@ -233,6 +233,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/IBanco.cs
+++ b/BoletoNetCore/Banco/IBanco.cs
@@ -110,6 +110,7 @@ namespace BoletoNetCore
         void LerHeaderRetornoCNAB400(string registro);
         void CompletarHeaderRetornoCNAB400(string registro);
         void LerDetalheRetornoCNAB400Segmento1(ref Boleto boleto, string registro);
+        void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro);
         void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro);
         void LerTrailerRetornoCNAB400(string registro);
     }

--- a/BoletoNetCore/Banco/Itau/BancoItau.CNAB400.cs
+++ b/BoletoNetCore/Banco/Itau/BancoItau.CNAB400.cs
@@ -267,6 +267,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento1(ref Boleto boleto, string registro)
         {
             try

--- a/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
+++ b/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
@@ -79,6 +79,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
+++ b/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
@@ -257,6 +257,11 @@ namespace BoletoNetCore
         {
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             

--- a/BoletoNetCore/Banco/Sicoob/BancoSicoob.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicoob/BancoSicoob.CNAB400.cs
@@ -362,6 +362,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
@@ -422,6 +422,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/UniprimeNortePR/BancoUniprimeNortePR.CNAB400.cs
+++ b/BoletoNetCore/Banco/UniprimeNortePR/BancoUniprimeNortePR.CNAB400.cs
@@ -260,6 +260,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
             throw new System.NotImplementedException();

--- a/BoletoNetCore/Boleto/Boleto.cs
+++ b/BoletoNetCore/Boleto/Boleto.cs
@@ -240,6 +240,8 @@ namespace BoletoNetCore
         public ObservableCollection<GrupoDemonstrativo> Demonstrativos { get; } = new ObservableCollection<GrupoDemonstrativo>();
         public string ParcelaInformativo { get; set; } = string.Empty;
         public string ByteNossoNumero { get; set; } = "2";
+        public string QRCode { get; set; }
+        public string TxId { get; set; }
 
         public NotaFiscalEletronica NFe { get; set; } = new NotaFiscalEletronica();
 


### PR DESCRIPTION


Segue sugestão de PR da implementação da leitura do segmento 4 para retorno do layout 400 Bradesco. Esse segmento é usado para boleto híbridos, onde vem o qrcode gerado automaticamente pelo banco. No arquivo de remessa não há alteração, pois isso é um configuração feita apenas pelo banco. Aprovei e adicionei alguns testes de retorno também. 

Sobre os campos criados na classe boleto, tentei seguir o padrão do projeto BoletoNet, onde já existe uma propriedade chamada 'QrCode'.

Segue layout:
<img width="782" height="502" alt="LayoutRetorno400Bradesco" src="https://github.com/user-attachments/assets/2796ef14-72ff-4d54-9924-3ea7c6f00313" />