### PR TITLE
Remessa e retorno boleto híbrido Santander

### DIFF
--- a/BoletoNetCore/Arquivo/ArquivoRetorno.cs
+++ b/BoletoNetCore/Arquivo/ArquivoRetorno.cs
@@ -218,6 +218,9 @@ namespace BoletoNetCore
                 case "1":
                     b.LerDetalheRetornoCNAB400Segmento1(ref boleto, registro);
                     break;
+                case "2":
+                    b.LerDetalheRetornoCNAB400Segmento2(ref boleto, registro);
+                    break;
                 case "4":
                     b.LerDetalheRetornoCNAB400Segmento4(ref boleto, registro);
                     break;

--- a/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB400.cs
+++ b/BoletoNetCore/Banco/BancoBrasil/BancoBrasil.CNAB400.cs
@@ -233,6 +233,11 @@ namespace BoletoNetCore
             throw new NotImplementedException();
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();
@@ -497,7 +502,5 @@ namespace BoletoNetCore
         {
 
         }
-
-
     }
 }

--- a/BoletoNetCore/Banco/BancoInter/BancoInter.CNAB400.cs
+++ b/BoletoNetCore/Banco/BancoInter/BancoInter.CNAB400.cs
@@ -301,6 +301,11 @@ namespace BoletoNetCore
         {
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Banrisul/BancoBanrisul.CNAB400.cs
+++ b/BoletoNetCore/Banco/Banrisul/BancoBanrisul.CNAB400.cs
@@ -390,6 +390,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Bradesco/BancoBradesco.CNAB400.cs
+++ b/BoletoNetCore/Banco/Bradesco/BancoBradesco.CNAB400.cs
@@ -75,6 +75,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             boleto.QRCode = registro.Substring(28, 77);

--- a/BoletoNetCore/Banco/Caixa/BancoCaixa.CNAB400.cs
+++ b/BoletoNetCore/Banco/Caixa/BancoCaixa.CNAB400.cs
@@ -207,6 +207,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Cecred/BancoCecred.CNAB400.cs
+++ b/BoletoNetCore/Banco/Cecred/BancoCecred.CNAB400.cs
@@ -258,6 +258,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/CrediSis/BancoCrediSIS.CNAB400.cs
+++ b/BoletoNetCore/Banco/CrediSis/BancoCrediSIS.CNAB400.cs
@@ -258,6 +258,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Daycoval/BancoDaycoval.CNAB400.cs
+++ b/BoletoNetCore/Banco/Daycoval/BancoDaycoval.CNAB400.cs
@@ -233,6 +233,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/IBanco.cs
+++ b/BoletoNetCore/Banco/IBanco.cs
@@ -110,6 +110,7 @@ namespace BoletoNetCore
         void LerHeaderRetornoCNAB400(string registro);
         void CompletarHeaderRetornoCNAB400(string registro);
         void LerDetalheRetornoCNAB400Segmento1(ref Boleto boleto, string registro);
+        void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro);
         void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro);
         void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro);
         void LerTrailerRetornoCNAB400(string registro);

--- a/BoletoNetCore/Banco/Itau/BancoItau.CNAB400.cs
+++ b/BoletoNetCore/Banco/Itau/BancoItau.CNAB400.cs
@@ -267,6 +267,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
+++ b/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
@@ -79,6 +79,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
+++ b/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
@@ -15,7 +15,7 @@ namespace BoletoNetCore
             var detalhe = GerarDetalheRemessaCNAB400Registro1(boleto, ref registro);
 
             // Registro 8 - Boleto com Pix - Registro Opcional
-            var strline = GerarDetalheRemessaCNAB400Registro2(boleto, ref registro);
+            var strline = GerarDetalheRemessaCNAB400Registro8(boleto, ref registro);
             if (!string.IsNullOrWhiteSpace(strline))
             {
                 detalhe += Environment.NewLine;
@@ -24,7 +24,7 @@ namespace BoletoNetCore
             return detalhe;
         }
 
-        private string GerarDetalheRemessaCNAB400Registro2(Boleto boleto, ref int numeroRegistroGeral)
+        private string GerarDetalheRemessaCNAB400Registro8(Boleto boleto, ref int numeroRegistroGeral)
         {
             try
             {

--- a/BoletoNetCore/Banco/Santander/BancoSantander.cs
+++ b/BoletoNetCore/Banco/Santander/BancoSantander.cs
@@ -12,7 +12,7 @@ namespace BoletoNetCore
             Codigo = 033;
             Nome = "Santander";
             Digito = "7";
-            IdsRetornoCnab400RegistroDetalhe = new List<string> { "1" };
+            IdsRetornoCnab400RegistroDetalhe = new List<string> { "1", "2" };
             RemoveAcentosArquivoRemessa = true;
         }
 

--- a/BoletoNetCore/Banco/Sicoob/BancoSicoob.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicoob/BancoSicoob.CNAB400.cs
@@ -362,6 +362,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
+++ b/BoletoNetCore/Banco/Sicredi/BancoSicredi.CNAB400.cs
@@ -422,6 +422,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Banco/UniprimeNortePR/BancoUniprimeNortePR.CNAB400.cs
+++ b/BoletoNetCore/Banco/UniprimeNortePR/BancoUniprimeNortePR.CNAB400.cs
@@ -260,6 +260,11 @@ namespace BoletoNetCore
             }
         }
 
+        public void LerDetalheRetornoCNAB400Segmento2(ref Boleto boleto, string registro)
+        {
+            throw new NotImplementedException();
+        }
+
         public void LerDetalheRetornoCNAB400Segmento4(ref Boleto boleto, string registro)
         {
             throw new NotImplementedException();

--- a/BoletoNetCore/Boleto/ContaBancaria.cs
+++ b/BoletoNetCore/Boleto/ContaBancaria.cs
@@ -22,6 +22,8 @@ namespace BoletoNetCore
         public string MensagemFixaTopoBoleto { get; set; } = "";
         public string MensagemFixaPagador { get; set; } = "";
         public int CodigoBancoCorrespondente { get; set; }
+        public string ChavePix { get; set; }
+        public TipoChavePix TipoChavePix { get; set; }
         public string NossoNumeroBancoCorrespondente { get; set; }
         public string CodigoConvenio { get; set; } // Detalhamento do tipo de cobrança que você contatou. Veja com o gerente de banco
         public TipoDistribuicaoBoleto TipoDistribuicao { get; set; } = TipoDistribuicaoBoleto.ClienteDistribui;

--- a/BoletoNetCore/Enums/TipoChavePix.cs
+++ b/BoletoNetCore/Enums/TipoChavePix.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace BoletoNetCore
+{
+    public enum TipoChavePix
+    {
+        CPF = 1,
+        CNPJ = 2,
+        Celular = 3,
+        Email = 4,
+        Aleatoria = 5
+    }
+}


### PR DESCRIPTION
Segue sugestão de PR com implementação do boleto hibrido com layout 400 para o banco Santander.

Para isso foi adicionado 2 propriedades na entidade ContaBancaria, sendo que na remessa se a propriedade "ChavePix"  for preenchida, será gerado o segmento 8.

No retorno, foi implementado a leitura do segmento 2.

Por fim, adicionei testes na remessa e retorno para esse layout. 

[Link layout do banco](https://cms.santander.com.br/sites/WPS/documentos/arq-layout-de-arquivos-download-cob400ptbr/25-05-06_134057_cobranca-353_400+posi%C3%A7%C3%B5es-v.+2.35-abril-2024-ptbr.pdf)

