### PR TITLE
#373-Ajuste no CNAB 400 do Banco Safra para preencher ValorPago corretamente.

### DIFF
--- a/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
+++ b/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
@@ -57,7 +57,7 @@ namespace BoletoNetCore
                 boleto.ValorIOF = Convert.ToDecimal(registro.Substring(214, 13)) / 100;
                 boleto.ValorAbatimento = Convert.ToDecimal(registro.Substring(227, 13)) / 100;
                 boleto.ValorDesconto = Convert.ToDecimal(registro.Substring(240, 13)) / 100;
-                boleto.ValorPagoCredito = Convert.ToDecimal(registro.Substring(253, 13)) / 100;
+                boleto.ValorPago = Convert.ToDecimal(registro.Substring(253, 13)) / 100;
                 boleto.ValorJurosDia = Convert.ToDecimal(registro.Substring(266, 13)) / 100;
                 boleto.ValorOutrosCreditos = Convert.ToDecimal(registro.Substring(279, 13)) / 100;
 

--- a/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
+++ b/BoletoNetCore/Banco/Safra/BancoSafra.CNAB400.cs
@@ -58,6 +58,7 @@ namespace BoletoNetCore
                 boleto.ValorAbatimento = Convert.ToDecimal(registro.Substring(227, 13)) / 100;
                 boleto.ValorDesconto = Convert.ToDecimal(registro.Substring(240, 13)) / 100;
                 boleto.ValorPago = Convert.ToDecimal(registro.Substring(253, 13)) / 100;
+                boleto.ValorPagoCredito = Convert.ToDecimal(registro.Substring(253, 13)) / 100; //Mantido esse campo para não quebrar o projeto - Detalhes na issue #373
                 boleto.ValorJurosDia = Convert.ToDecimal(registro.Substring(266, 13)) / 100;
                 boleto.ValorOutrosCreditos = Convert.ToDecimal(registro.Substring(279, 13)) / 100;
 


### PR DESCRIPTION
- Corrigido mapeamento do campo "Valor Pago" no retorno CNAB 400 do Banco Safra
- Antes o valor estava sendo atribuído a ValorPagoCredito, o que não está de acordo
  com o manual do banco e gerava inconsistência
- Agora o campo correto ValorPago é preenchido, garantindo compatibilidade com o manual do Safra