### PR TITLE
Leitura retorno bancário Santander 400

### DIFF
--- a/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
+++ b/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
@@ -230,6 +230,7 @@ namespace BoletoNetCore
                 if (registro.Substring(79, 15).TrimEnd() != "SANTANDER")
                     throw new Exception("O arquivo não é do tipo \"SANTANDER\"");
 
+                this.Beneficiario = this.Beneficiario ?? new Beneficiario();
                 this.Beneficiario.ContaBancaria = this.Beneficiario.ContaBancaria ?? new ContaBancaria();
                 
                 this.Beneficiario.ContaBancaria.Agencia = registro.Substring(26, 4);


### PR DESCRIPTION
Adicionado proteção para quando o beneficiário for nulo na leitura do retorno bancário Santander.