### PR TITLE
Fix linha digitável: .w450 + ocultar .w150 vazia + fallback de fontes no Linux

### DIFF
--- a/BoletoNetCore/BoletoImpressao/BoletoNet.css
+++ b/BoletoNetCore/BoletoImpressao/BoletoNet.css
@@ -21,16 +21,16 @@ img {
 }
 
 .cp {
-    font: bold 10px arial;
+    font: bold 10px Arial, "Liberation Sans", sans-serif;
     color: #000000;
 }
 
 .ti {
-	font: 9px arial, helvetica, sans-serif;
+	font: 9px Arial, "Liberation Sans", Helvetica, sans-serif;
 }
 
 .ld {
-	font: bold 15px arial;
+	font: bold 15px Arial, "Liberation Sans", sans-serif;
 	color: #000000;
 }
 
@@ -39,22 +39,22 @@ img {
 }
 
 .ct {
-    font: 9px "arial narrow";
+    font: 9px "Arial Narrow", "Liberation Sans Narrow", sans-serif;
     color: #000000;
 }
 
 .cn {
-    font: 9px arial;
+    font: 9px Arial, "Liberation Sans", sans-serif;
     color: #000000;
 }
 
 .cn8 {
-    font: 8px arial;
+    font: 8px Arial, "Liberation Sans", sans-serif;
     color: #000000;
 }
 
 .bc {
-    font: bold 22px arial;
+    font: bold 22px Arial, "Liberation Sans", sans-serif;
     color: #000000;
 }
 
@@ -92,12 +92,12 @@ img {
 }
 
 .cpN {
-    font: bold 10px arial;
+    font: bold 10px Arial, "Liberation Sans", sans-serif;
     color: #000000;
 }
 
 .ctN {
-    font: 9px "arial narrow";
+    font: 9px "Arial Narrow", "Liberation Sans Narrow", sans-serif;
     color: #000000;
 }
 
@@ -367,13 +367,13 @@ img {
 }
 
 .rc6 .t {
-	font: 9px "arial narrow";
+	font: 9px "Arial Narrow", "Liberation Sans Narrow", sans-serif;
 	color: #000033;
 	height: 13px;
 }
 
 .rc6 .c {
-	font: bold 10px arial;
+	font: bold 10px Arial, "Liberation Sans", sans-serif;
 	color: black;
 	height: 12px;
 }

--- a/BoletoNetCore/BoletoImpressao/BoletoNetPDF.css
+++ b/BoletoNetCore/BoletoImpressao/BoletoNetPDF.css
@@ -21,16 +21,16 @@ img {
 }
 
 .cp {
-	font: bold 10px arial;
+	font: bold 10px Arial, "Liberation Sans", sans-serif;
 	color: black;
 }
 
 .ti {
-	font: 9px arial, helvetica, sans-serif;
+	font: 9px Arial, "Liberation Sans", Helvetica, sans-serif;
 }
 
 .ld {
-	font: bold 15px arial;
+	font: bold 15px Arial, "Liberation Sans", sans-serif;
 	color: #000000;
 }
 
@@ -39,17 +39,17 @@ img {
 }
 
 .ct {
-	font: 9px "arial narrow";
+	font: 9px "Arial Narrow", "Liberation Sans Narrow", sans-serif;
 	color: #000033;
 }
 
 .cn {
-	font: 9px arial;
+	font: 9px Arial, "Liberation Sans", sans-serif;
 	color: black;
 }
 
 .bc {
-	font: bold 22px arial;
+	font: bold 22px Arial, "Liberation Sans", sans-serif;
 	color: #000000;
 }
 
@@ -87,12 +87,12 @@ img {
 }
 
 .cpN {
-	font: bold 10px arial;
+	font: bold 10px Arial, "Liberation Sans", sans-serif;
 	color: black;
 }
 
 .ctN {
-	font: 9px "arial narrow";
+	font: 9px "Arial Narrow", "Liberation Sans Narrow", sans-serif;
 	color: #000033;
 }
 
@@ -360,13 +360,13 @@ img {
 }
 
 .rc6 .t {
-	font: 9px "arial narrow";
+	font: 9px "Arial Narrow", "Liberation Sans Narrow", sans-serif;
 	color: #000033;
 	height: 13px;
 }
 
 .rc6 .c {
-	font: bold 10px arial;
+	font: bold 10px Arial, "Liberation Sans", sans-serif;
 	color: black;
 	height: 12px;
 }


### PR DESCRIPTION
Closes #379 

### Mudanças
- Ajusta `.w450` para `width: 450px` (BoletoNet.css + BoletoNetPDF.css)
- Oculta `.w150` quando vazia: `.w150:empty { display: none; }`
- Adiciona fallback de fontes para Linux/container: `"Liberation Sans"` / `"Liberation Sans Narrow"`

### Motivo
Corrige cenários onde a linha digitável quebrava/truncava no boleto, especialmente em renderização via Chromium/Playwright em Linux.

### Evidencias
Detalhado em issue #379 
