### PR TITLE
Adiciona leitura do segmento G da Varredura DDA no CNAB240

### DIFF
--- a/BoletoNetCore.Testes/Bancos/Itau/BancoItauRetornoVarreduraDdaTests.cs
+++ b/BoletoNetCore.Testes/Bancos/Itau/BancoItauRetornoVarreduraDdaTests.cs
@@ -1,0 +1,60 @@
+using System;
+using NUnit.Framework;
+
+namespace BoletoNetCore.Testes
+{
+    /// <summary>
+    /// Leitura do retorno de Varredura DDA (Débito Direto Autorizado) - segmento G do CNAB240.
+    /// Diferente do retorno de cobrança (T/U), a varredura traz os boletos registrados a pagar
+    /// contra o sacado. Validado com um registro de segmento G montado nas posições do layout.
+    /// </summary>
+    [TestFixture]
+    [Category("Itau Varredura DDA")]
+    public class BancoItauRetornoVarreduraDdaTests
+    {
+        // Monta uma linha CNAB240 (240 posições preenchidas com espaço) e aplica os campos por posição.
+        private static string MontarRegistro(Action<char[]> preencher)
+        {
+            var registro = new string(' ', 240).ToCharArray();
+            preencher(registro);
+            return new string(registro);
+        }
+
+        private static void Set(char[] registro, int posicao, string valor)
+        {
+            for (int i = 0; i < valor.Length; i++)
+                registro[posicao + i] = valor[i];
+        }
+
+        [Test]
+        public void Deve_ler_segmento_G_da_varredura_dda_itau()
+        {
+            var codigoBarras = "3419".PadRight(44, '0'); // 44 posições (conteúdo sintético)
+
+            var segmentoG = MontarRegistro(r =>
+            {
+                Set(r, 0, "341");               // código do banco
+                Set(r, 7, "3");                 // tipo de registro (detalhe)
+                Set(r, 13, "G");                // segmento
+                Set(r, 15, "01");               // código de movimento (entrada de títulos)
+                Set(r, 17, codigoBarras);       // campo livre / código de barras (44)
+                Set(r, 107, "17062026");        // vencimento (DDMMAAAA)
+                Set(r, 115, "000000001806455"); // valor (15) => 18.064,55
+                Set(r, 147, "987654321098765"); // número do documento (15) - posições 148-162
+            });
+
+            var banco = (IBancoCNAB240)Banco.Instancia(341);
+            var boleto = new Boleto((IBanco)banco, ignorarCarteira: true);
+
+            banco.LerDetalheRetornoCNAB240SegmentoG(ref boleto, segmentoG);
+
+            Assert.AreEqual(new DateTime(2026, 6, 17), boleto.DataVencimento, "Vencimento");
+            Assert.AreEqual(18064.55M, boleto.ValorTitulo, "Valor do título");
+            Assert.AreEqual("987654321098765", boleto.NumeroDocumento, "Número do documento");
+            Assert.AreEqual(codigoBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de barras");
+            Assert.AreEqual("01", boleto.CodigoMovimentoRetorno, "Código de movimento");
+            Assert.AreEqual("Entrada de Títulos", boleto.DescricaoMovimentoRetorno, "Descrição do movimento (varredura DDA)");
+            Assert.IsNotEmpty(boleto.CodigoBarra.LinhaDigitavel, "Linha digitável derivada do código de barras");
+        }
+    }
+}

--- a/BoletoNetCore/Arquivo/ArquivoRetorno.cs
+++ b/BoletoNetCore/Arquivo/ArquivoRetorno.cs
@@ -159,6 +159,15 @@ namespace BoletoNetCore
                     Boletos.Add(boleto);
                     return;
                 }
+
+                if (tipoSegmento == 'G')
+                {
+                    // Segmento G - Varredura DDA (Débito Direto Autorizado): cada G indica um boleto a pagar
+                    var boleto = new Boleto(this.Banco, _ignorarCarteiraBoleto);
+                    b.LerDetalheRetornoCNAB240SegmentoG(ref boleto, registro);
+                    Boletos.Add(boleto);
+                    return;
+                }
             }
         }
 

--- a/BoletoNetCore/Banco/BancoFebraban.CNAB240.cs
+++ b/BoletoNetCore/Banco/BancoFebraban.CNAB240.cs
@@ -147,5 +147,53 @@ namespace BoletoNetCore
         public virtual void LerDetalheRetornoCNAB240SegmentoA(ref Boleto boleto, string registro)
         {
         }
+
+        /// <summary>
+        /// Segmento G - Varredura DDA (Débito Direto Autorizado). Diferente do retorno de cobrança
+        /// (segmentos T/U), a varredura traz os boletos registrados a pagar contra o sacado, com layout
+        /// padrão CNAB240 FEBRABAN do segmento G. Cada segmento G representa um título a pagar.
+        /// </summary>
+        public virtual void LerDetalheRetornoCNAB240SegmentoG(ref Boleto boleto, string registro)
+        {
+            try
+            {
+                // Código de movimento (situação do título no DDA)
+                boleto.CodigoMovimentoRetorno = registro.Substring(15, 2);
+                boleto.DescricaoMovimentoRetorno = Cnab.MovimentoVarreduraDDACnab240(boleto.CodigoMovimentoRetorno);
+
+                // Código de barras (campo livre do segmento G - 44 posições)
+                var codigoBarras = registro.Substring(17, 44).Trim();
+                if (codigoBarras.Length == 44)
+                {
+                    boleto.CodigoBarra.CodigoDeBarras = codigoBarras;
+
+                    // Linha digitável derivada do código de barras. Boletos de cobrança usam o layout
+                    // padrão (campo livre nas posições 20-44); arrecadação (inicia em 8) tem outro layout.
+                    if (!codigoBarras.StartsWith("8"))
+                    {
+                        boleto.CodigoBarra.CampoLivre = codigoBarras.Substring(19, 25);
+                        Banco.FormataLinhaDigitavel(boleto);
+                    }
+                }
+
+                // Número do documento de cobrança (DP, NF...) - posições 148-162 do segmento G.
+                boleto.NumeroDocumento = registro.Substring(147, 15).Trim();
+
+                // Data de vencimento (DDMMAAAA)
+                var vencimento = Utils.ToInt32(registro.Substring(107, 8));
+                if (vencimento > 0)
+                    boleto.DataVencimento = Utils.ToDateTime(vencimento.ToString("##-##-####"));
+
+                // Valor do título
+                boleto.ValorTitulo = Convert.ToDecimal(registro.Substring(115, 15)) / 100;
+
+                // Registro Retorno
+                boleto.RegistroArquivoRetorno = boleto.RegistroArquivoRetorno + registro + Environment.NewLine;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro ao ler detalhe do arquivo de RETORNO / CNAB 240 / G (Varredura DDA).", ex);
+            }
+        }
     }
 }

--- a/BoletoNetCore/Banco/IBanco.cs
+++ b/BoletoNetCore/Banco/IBanco.cs
@@ -146,6 +146,7 @@ namespace BoletoNetCore
         void LerDetalheRetornoCNAB240SegmentoT(ref Boleto boleto, string registro);
         void LerDetalheRetornoCNAB240SegmentoU(ref Boleto boleto, string registro);
         void LerDetalheRetornoCNAB240SegmentoA(ref Boleto boleto, string regitro);
+        void LerDetalheRetornoCNAB240SegmentoG(ref Boleto boleto, string registro);
     }
 
 

--- a/BoletoNetCore/Util/Cnab.cs
+++ b/BoletoNetCore/Util/Cnab.cs
@@ -89,6 +89,55 @@ namespace BoletoNetCore
         }
 
         /// <summary>
+        /// Descrição do código de movimento do segmento G da Varredura DDA (Débito Direto Autorizado).
+        /// Difere do retorno de cobrança (MovimentoRetornoCnab240): o domínio aqui é o de
+        /// movimento/comando do título, conforme o manual de Varredura DDA (CNAB240, nota "Código de Movimento").
+        /// </summary>
+        public static string MovimentoVarreduraDDACnab240(string codigo)
+        {
+            switch (codigo)
+            {
+                case "01": return "Entrada de Títulos";
+                case "02": return "Pedido de Baixa";
+                case "03": return "Protesto para Fins Falimentares";
+                case "04": return "Concessão de Abatimento";
+                case "05": return "Cancelamento de Abatimento";
+                case "06": return "Alteração de Vencimento";
+                case "07": return "Concessão de Desconto";
+                case "08": return "Cancelamento de Desconto";
+                case "09": return "Protestar";
+                case "10": return "Sustar Protesto e Baixar Título";
+                case "11": return "Sustar Protesto e Manter em Carteira";
+                case "12": return "Alteração de Juros de Mora";
+                case "13": return "Dispensar Cobrança de Juros de Mora";
+                case "14": return "Alteração de Valor/Percentual de Multa";
+                case "15": return "Dispensar Cobrança de Multa";
+                case "16": return "Alteração do Valor de Desconto";
+                case "17": return "Não conceder Desconto";
+                case "18": return "Alteração do Valor de Abatimento";
+                case "19": return "Prazo Limite de Recebimento - Alterar";
+                case "20": return "Prazo Limite de Recebimento - Dispensar";
+                case "21": return "Alterar número do título dado pelo cedente";
+                case "22": return "Alterar número controle do Participante";
+                case "23": return "Alterar dados do Sacado";
+                case "24": return "Alterar dados do Sacador/Avalista";
+                case "30": return "Recusa da Alegação do Sacado";
+                case "31": return "Alteração de Outros Dados";
+                case "33": return "Alteração dos Dados do Rateio de Crédito";
+                case "34": return "Pedido de Cancelamento dos Dados do Rateio de Crédito";
+                case "35": return "Pedido de Desagendamento do Débito Automático";
+                case "40": return "Alteração de Carteira";
+                case "41": return "Cancelar protesto";
+                case "42": return "Alteração de Espécie de Título";
+                case "43": return "Transferência de carteira/modalidade de cobrança";
+                case "44": return "Alteração de contrato de cobrança";
+                case "45": return "Negativação Sem Protesto";
+                case "46": return "Solicitação de Baixa de Título Negativado Sem Protesto";
+                default: return "";
+            }
+        }
+
+        /// <summary>
         /// Recupera a Lista dos Motivos de Ocorrência na Cobrança conforme C047
         /// </summary>
         /// <remarks> Poderão ser


### PR DESCRIPTION
#404 Leitura do retorno de Varredura DDA (segmento G)

## Resumo

Adiciona suporte à leitura do segmento G no retorno CNAB240, usado na Varredura DDA do Itaú para identificar boletos registrados contra o sacado.

## Alterações

- Incluída a leitura do segmento `G` no processamento de retorno CNAB240.
- Adicionado método `LerDetalheRetornoCNAB240SegmentoG` à interface `IBancoCNAB240`.
- Implementada leitura padrão FEBRABAN para:
  - código de movimento;
  - descrição do movimento DDA;
  - código de barras;
  - linha digitável;
  - número do documento;
  - data de vencimento;
  - valor do título.
- Adicionado mapeamento dos códigos de movimento da Varredura DDA.
- Criado teste cobrindo a leitura de um registro sintético de segmento G do Itaú.

## Validação

- Adicionado teste unitário `BancoItauRetornoVarreduraDdaTests`.