### PR TITLE
Santander CNAB400: parametriza Complemento da Conta Cobrança posições 384-385

### DIFF
--- a/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
+++ b/BoletoNetCore/Banco/Santander/BancoSantander.CNAB400.cs
@@ -187,8 +187,11 @@ namespace BoletoNetCore
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0335, 015, 0, boleto.Pagador.Endereco.Cidade, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0350, 002, 0, boleto.Pagador.Endereco.UF, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0352, 031, 0, string.Empty, ' ');
+                // Posições 383-385: Conta Cobrança nova de 10 posições (9 dígitos + DV) - Manual H7800 CNAB400 Santander
+                // 383     = Identificador do complemento: "I" indica uso de conta cobrança com 10 posições
+                // 384-385 = Complemento da conta cobrança: 9º dígito da conta + dígito verificador (CCCCCCCCC-D)
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0383, 001, 0, 'I', ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0384, 002, 0, 32, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0384, 002, 0, boleto.Banco.Beneficiario.ContaBancaria.Conta.Right(1) + boleto.Banco.Beneficiario.ContaBancaria.DigitoConta, '0');
 
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0386, 009, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');


### PR DESCRIPTION
…s 384-385)

O valor estava fixo em "32", que na verdade é o final da conta cobrança (9º dígito + DV) de uma conta específica. Conforme o manual H7800 do Santander (Layout de Cobrança CNAB 400, v2.30, págs. 19-20), as posições 383-385 do Registro Movimento identificam a conta cobrança nova de 10 posições (CCCCCCCCC-D):

- 383: Identificador "I" (conta cobrança com 10 posições)
- 384-385: Complemento = 9º dígito da conta cobrança + dígito verificador

Agora o complemento é derivado de ContaBancaria.Conta (9 dígitos) + ContaBancaria.DigitoConta, conforme o exemplo do próprio manual (conta 001234567-8 gera complemento "78").